### PR TITLE
feat: add ticket load command and improve ticket CLI

### DIFF
--- a/dialtone.sh
+++ b/dialtone.sh
@@ -136,8 +136,15 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help|help)
-            print_help
-            exit 0
+            # Only show shell help if no command set yet
+            if [ -z "$DIALTONE_CMD" ]; then
+                print_help
+                exit 0
+            else
+                # Pass --help to the subcommand
+                ARGS+=("$1")
+                shift
+            fi
             ;;
         *)
             if [ -z "$DIALTONE_CMD" ]; then

--- a/src/core/install/install.go
+++ b/src/core/install/install.go
@@ -304,6 +304,8 @@ func installLocalDepsWSL() {
 	headerFile := filepath.Join(includeDir, "linux", "videodev2.h")
 	if _, err := os.Stat(headerFile); err != nil {
 		logger.LogInfo("Step 3: Extracting V4L2 headers...")
+		// Save original directory to restore later
+		origDir, _ := os.Getwd()
 		err := os.Chdir(depsDir)
 		if err == nil {
 			cmd := exec.Command("apt-get", "download", "libv4l-dev", "linux-libc-dev")
@@ -314,8 +316,8 @@ func installLocalDepsWSL() {
 			runSimpleShell("dpkg -x libv4l-dev*.deb .")
 			runSimpleShell("dpkg -x linux-libc-dev*.deb .")
 			runSimpleShell("rm *.deb")
-			home, _ := os.UserHomeDir()
-			os.Chdir(home)
+			// Restore original directory
+			os.Chdir(origDir)
 			logItemStatus("V4L2 Headers", "latest", headerFile, false)
 		}
 	} else {

--- a/src/tickets/ticket-load-command/test/test.go
+++ b/src/tickets/ticket-load-command/test/test.go
@@ -1,0 +1,12 @@
+package test
+import (
+	"dialtone/cli/src/dialtest"
+)
+func init() {
+	dialtest.RegisterTicket("ticket-load-command")
+	dialtest.AddSubtaskTest("init", RunInitTest, nil)
+}
+func RunInitTest() error {
+	// TODO: Implement verification logic for subtask 'init'
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `ticket load` command to import duckdb backups from `src/tickets/*/` directories
- Fix `install.go` working directory bug that prevented AI plugin install (was changing to home dir instead of restoring original)
- Fix `ticket --help` to show plugin-specific help instead of main dialtone help
- Add `subtask add` and `subtask status` commands for managing ticket subtasks

## Test plan
- [x] Run `./dialtone.sh install` - AI plugin now installs successfully
- [x] Run `./dialtone.sh ticket load` - loads 3 duckdb backups
- [x] Run `./dialtone.sh ticket --help` - shows ticket-specific help
- [x] Run `./dialtone.sh ticket subtask add <name>` - adds subtask to current ticket
- [x] Run `./dialtone.sh ticket subtask status <name> done` - updates subtask status