### PR TITLE
Fix remote browser interop and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 ROBOT_HOST=192.168.1.x
 ROBOT_USER=user
 ROBOT_PASSWORD=password
+ROBOT_PORT=22
 
 # Tailscale Auth Key (Required for headless operation)
 TS_AUTHKEY=tskey-auth-xxxxx
@@ -29,3 +30,7 @@ DIALTONE_DEV_ENV=./dialtone_dev_dependencies
 OPENCODE_API_KEY=your-opencode-api-key
 # GOOGLE API KEY
 GOOGLE_API_KEY=your-google-api-key
+
+# Testing Configuration
+CAD_LIVE=false
+HEADLESS=false


### PR DESCRIPTION
This PR introduces absolute path resolution for Windows binaries in WSL to ensure tools like  work over SSH. It also updates  with testing variables (, , ).