### PR TITLE
feat(www): Radio section, threejs/webgpu templates, VisibilityMixin frameCount

### DIFF
--- a/src/plugins/www/README.md
+++ b/src/plugins/www/README.md
@@ -2,6 +2,33 @@
 
 Vercel wrapper for the public website at [dialtone.earth](https://dialtone.earth).
 
+## Simplest working section: `threejs-template`
+
+The **threejs-template** component is the minimal example of a working Three.js section. Use it as the starting point for new sections.
+
+- **Component:** `app/src/components/threejs-template.ts`
+- **Section ID:** `s-threejs-template` · **Container:** `#threejs-template-container`
+- **Scene:** One cube in the center, camera facing it, key light and soft glow shader. Implements `VisualizationControl` (dispose, setVisible) and uses `VisibilityMixin` so the section manager can lazy-load and pause when off-screen.
+
+To add a section like this:
+
+1. Add a `<section id="s-yourid" class="snap-slide">` with `<div id="yourid-container"></div>` in `index.html`.
+2. Add `#yourid-container` (and `#yourid-container canvas`) to the visualization container rules in `style.css`.
+3. Register in `main.ts`: `sections.register('s-yourid', { containerId: 'yourid-container', load: async () => { ... mountYour(container) ... } });`
+4. Implement a mount function that returns `{ dispose, setVisible }` and a visualization that respects `setVisible` in its animation loop.
+
+See `threejs-template.ts` and `section.ts` for the contract.
+
+## WebGPU template: `webgpu-template`
+
+The **webgpu-template** component is the minimal example of a working WebGPU section (no Three.js). Use it as the starting point for new WebGPU-based sections.
+
+- **Component:** `app/src/components/webgpu-template.ts`
+- **Section ID:** `s-webgpu-template` · **Container:** `#webgpu-template-container`
+- **Scene:** Lit sphere, WGSL shaders, adapter/device/context setup, depth buffer, uniform buffer, and the same `{ dispose, setVisible }` contract as other sections.
+
+Run `./dialtone.sh www webgpu demo` to open the WebGPU template section. When WebGPU is unavailable, the section shows a fallback message instead of a canvas.
+
 ## Folder Structure
 
 ```shell
@@ -12,11 +39,10 @@ src/plugins/www/
 │   ├── index.html       # Landing page with version tag
 │   ├── package.json     # Version and dependencies
 │   ├── vite.config.mjs  # Vite build config
-│   ├── vercel.json      # Rewrites for /about, /docs
+│   ├── vercel.json      
 │   └── src/
 │       ├── main.ts
 │       ├── components/  # Earth, neural network, etc.
-│       ├── pages/       # about.html, docs.html
 │       └── shaders/     # GLSL shaders
 └── README.md
 ```
@@ -31,7 +57,24 @@ src/plugins/www/
 ./dialtone.sh www logs <url>       # View deployment logs
 ./dialtone.sh www domain [url]     # Alias deployment to dialtone.earth
 ./dialtone.sh www login            # Login to Vercel
+./dialtone.sh www radio demo       # Dev server + Chrome on Radio section (#s-radio)
+./dialtone.sh www cad demo         # CAD backend + dev server + Chrome on CAD section
+./dialtone.sh www earth demo       # Dev server + Chrome on Earth section
+./dialtone.sh www webgpu demo      # Dev server + Chrome on WebGPU section
 ```
+
+## Sections
+
+- **s-threejs-template** — Three.js template (cube + key light + glow); use as example for new sections
+- **s-home** — Earth visualization
+- **s-robot** — Robot arm IK
+- **s-neural** — Neural network
+- **s-math** — Math / geometry
+- **s-cad** — Parametric CAD (gear)
+- **s-webgpu-template** — WebGPU template (lit sphere; use as example for WebGPU sections)
+- **s-radio** — Open-source handheld radio (Three.js template)
+- **s-about** — About dialtone
+- **s-docs** — Documentation
 
 ## Publish Workflow
 

--- a/src/plugins/www/app/index.html
+++ b/src/plugins/www/app/index.html
@@ -14,7 +14,7 @@
     <header class="header-title">
       <h1>dialtone.earth</h1>
       <p class="version header-fps">FPS --</p>
-      <p class="version">v1.0.37</p>
+      <p class="version">v1.0.39</p>
     </header>
 
     <nav class="main-nav">
@@ -70,17 +70,27 @@
       <div id="cad-container"></div>
     </section>
 
-    <!-- Slide 6: WebGPU -->
-    <section id="s-webgpu" class="snap-slide" data-subtitle="webgpu sphere lighting" aria-label="WebGPU section">
-      <div id="webgpu-container"></div>
+    <!-- Slide 6: Radio -->
+    <section id="s-radio" class="snap-slide" data-subtitle="open-source radio for small robots" aria-label="Radio section">
+      <div id="radio-container"></div>
     </section>
 
-    <!-- Slide 7: About -->
+    <!-- Slide 7: WebGPU -->
+    <section id="s-webgpu-template" class="snap-slide" data-subtitle="simplest working WebGPU section" aria-label="WebGPU template section">
+      <div id="webgpu-template-container"></div>
+    </section>
+
+    <!-- Slide 8: Template (simplest section example) -->
+    <section id="s-threejs-template" class="snap-slide" data-subtitle="simplest working Three.js section" aria-label="Three.js template section">
+      <div id="threejs-template-container"></div>
+    </section>
+
+    <!-- Slide 9: About -->
     <section id="s-about" class="snap-slide" data-subtitle="about dialtone" aria-label="About section">
       <div id="about-container" style="width: 100%; transition: opacity 0.5s ease;"></div>
     </section>
 
-    <!-- Slide 8: Docs -->
+    <!-- Slide 10: Docs -->
     <section id="s-docs" class="snap-slide" data-subtitle="documentation" aria-label="Docs section">
       <div id="docs-container" style="width: 100%; transition: opacity 0.5s ease;"></div>
     </section>

--- a/src/plugins/www/app/package-lock.json
+++ b/src/plugins/www/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.37",
+  "version": "1.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialtone-www",
-      "version": "1.0.37",
+      "version": "1.0.39",
       "dependencies": {
         "d3": "^7.9.0",
         "h3-js": "^4.4.0",

--- a/src/plugins/www/app/package.json
+++ b/src/plugins/www/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.37",
+  "version": "1.0.39",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/plugins/www/app/src/components/radio.ts
+++ b/src/plugins/www/app/src/components/radio.ts
@@ -1,0 +1,239 @@
+import * as THREE from "three";
+import { FpsCounter } from "./fps";
+import { GpuTimer } from "./gpu_timer";
+import { VisibilityMixin } from "./section";
+import cubeGlowVert from "../shaders/template-cube.vert.glsl?raw";
+import cubeGlowFrag from "../shaders/template-cube.frag.glsl?raw";
+
+/**
+ * Radio section: aligned with threejs-template (key light, glow, FPS, backend).
+ * Handheld radio built from sub-components; slow oscillation animation.
+ */
+
+class RadioVisualization {
+  scene = new THREE.Scene();
+  camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  container: HTMLElement;
+  frameId = 0;
+  resizeObserver?: ResizeObserver;
+  gl!: WebGLRenderingContext | WebGL2RenderingContext;
+  gpuTimer = new GpuTimer();
+  isVisible = true;
+  private fpsCounter = new FpsCounter("radio");
+  private keyLight!: THREE.DirectionalLight;
+  private rimLight!: THREE.DirectionalLight;
+  private frontLight!: THREE.DirectionalLight;
+  private lightDir = new THREE.Vector3(1, 1, 1).normalize();
+
+  radioGroup = new THREE.Group();
+  bodyGroup = new THREE.Group();
+  lcdGroup = new THREE.Group();
+  antennasGroup = new THREE.Group();
+  knobsGroup = new THREE.Group();
+  private bodyMaterial!: THREE.ShaderMaterial;
+  private time = 0;
+  frameCount = 0;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+
+    this.renderer.setClearColor(0x000000, 1);
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+    const canvas = this.renderer.domElement;
+    canvas.style.position = "absolute";
+    canvas.style.top = "0";
+    canvas.style.left = "0";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+
+    const existingCanvas = container.querySelector("canvas");
+    if (existingCanvas) {
+      this.renderer.domElement = existingCanvas as HTMLCanvasElement;
+    } else {
+      this.container.appendChild(canvas);
+    }
+
+    this.camera.position.set(0, 0, 3);
+    this.camera.lookAt(0, 0, 0);
+
+    this.scene.add(new THREE.AmbientLight(0xccddff, 0.55));
+    this.keyLight = new THREE.DirectionalLight(0xffddbb, 1.8);
+    this.keyLight.position.set(4, 3, 2.5);
+    this.scene.add(this.keyLight);
+    this.rimLight = new THREE.DirectionalLight(0x88aaff, 1.2);
+    this.rimLight.position.set(-2.5, 1, -4);
+    this.scene.add(this.rimLight);
+    this.frontLight = new THREE.DirectionalLight(0xffffff, 0.9);
+    this.frontLight.position.set(0, 0, 5);
+    this.scene.add(this.frontLight);
+
+    this.buildRadio();
+    this.scene.add(this.radioGroup);
+
+    this.resize();
+    this.animate();
+
+    this.gl = this.renderer.getContext();
+    this.gpuTimer.init(this.gl);
+    this.updateBackendLabel();
+
+    if (typeof ResizeObserver !== "undefined") {
+      this.resizeObserver = new ResizeObserver(() => this.resize());
+      this.resizeObserver.observe(this.container);
+    } else {
+      window.addEventListener("resize", this.resize);
+    }
+  }
+
+  private buildRadio() {
+    const bodyW = 1.2;
+    const bodyH = 0.6;
+    const bodyD = 0.25;
+
+    // 1. Body (handheld case)
+    const bodyGeo = new THREE.BoxGeometry(bodyW, bodyH, bodyD);
+    const bodyMat = new THREE.ShaderMaterial({
+      uniforms: {
+        uColor: { value: new THREE.Color(0x5a6070) },
+        uGlowColor: { value: new THREE.Color(0x88aacc) },
+        uLightDir: { value: this.lightDir.clone() },
+        uTime: { value: 0 },
+      },
+      vertexShader: cubeGlowVert,
+      fragmentShader: cubeGlowFrag,
+    });
+    this.bodyMaterial = bodyMat;
+    const body = new THREE.Mesh(bodyGeo, bodyMat);
+    this.bodyGroup.add(body);
+    this.radioGroup.add(this.bodyGroup);
+
+    // 2. LCD screen (glow)
+    const screenGeo = new THREE.PlaneGeometry(0.5, 0.22);
+    const screenMat = new THREE.MeshStandardMaterial({
+      color: 0x00dd88,
+      emissive: 0x00aa55,
+      emissiveIntensity: 1.2,
+      side: THREE.DoubleSide,
+    });
+    const screen = new THREE.Mesh(screenGeo, screenMat);
+    screen.position.set(0, 0.12, bodyD / 2 + 0.01);
+    this.lcdGroup.add(screen);
+    this.radioGroup.add(this.lcdGroup);
+
+    // 3. Antennas
+    const antennaGeo = new THREE.CylinderGeometry(0.02, 0.02, 0.35, 12);
+    const antennaMat = new THREE.MeshStandardMaterial({
+      color: 0x3a3a42,
+      metalness: 0.5,
+      roughness: 0.4,
+    });
+    const antennaL = new THREE.Mesh(antennaGeo, antennaMat);
+    antennaL.position.set(-bodyW * 0.32, bodyH / 2 + 0.35 / 2, 0);
+    this.antennasGroup.add(antennaL);
+    const antennaR = new THREE.Mesh(antennaGeo, antennaMat);
+    antennaR.position.set(bodyW * 0.32, bodyH / 2 + 0.35 / 2, 0);
+    this.antennasGroup.add(antennaR);
+    this.radioGroup.add(this.antennasGroup);
+
+    // 4. Knobs
+    const knobGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.03, 16);
+    const knobMat = new THREE.MeshStandardMaterial({
+      color: 0x444450,
+      metalness: 0.3,
+      roughness: 0.5,
+    });
+    const knob1 = new THREE.Mesh(knobGeo, knobMat);
+    knob1.rotation.x = Math.PI / 2;
+    knob1.position.set(-0.35, -0.1, bodyD / 2 + 0.02);
+    this.knobsGroup.add(knob1);
+    const knob2 = new THREE.Mesh(knobGeo, knobMat);
+    knob2.rotation.x = Math.PI / 2;
+    knob2.position.set(0.35, -0.1, bodyD / 2 + 0.02);
+    this.knobsGroup.add(knob2);
+    this.radioGroup.add(this.knobsGroup);
+  }
+
+  resize = () => {
+    const rect = this.container.getBoundingClientRect();
+    const width = Math.max(1, rect.width);
+    const height = Math.max(1, rect.height);
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(width, height, false);
+  };
+
+  dispose() {
+    cancelAnimationFrame(this.frameId);
+    this.resizeObserver?.disconnect();
+    window.removeEventListener("resize", this.resize);
+    this.renderer.dispose();
+    if (this.container.contains(this.renderer.domElement)) {
+      this.container.removeChild(this.renderer.domElement);
+    }
+  }
+
+  setVisible(visible: boolean) {
+    VisibilityMixin.setVisible(this, visible, "radio");
+    if (!visible) this.fpsCounter.clear();
+  }
+
+  private getRenderBackend(): string {
+    if (typeof this.gl === "undefined") return "—";
+    return this.gl instanceof WebGL2RenderingContext ? "WebGL 2" : "WebGL 1";
+  }
+
+  private isWebGPUAvailable(): boolean {
+    return typeof navigator !== "undefined" && "gpu" in navigator;
+  }
+
+  private updateBackendLabel(): void {
+    const el = this.container.querySelector("[data-radio-backend]");
+    if (!el) return;
+    const backend = this.getRenderBackend();
+    const webgpu = this.isWebGPUAvailable();
+    el.textContent = `Rendering: ${backend} · WebGPU: ${webgpu ? "available" : "not available"}`;
+  }
+
+  animate = () => {
+    this.frameId = requestAnimationFrame(this.animate);
+    if (!this.isVisible) return;
+
+    this.time += 0.016;
+    this.frameCount++;
+    this.lightDir.copy(this.keyLight.position).normalize();
+    this.bodyMaterial.uniforms.uLightDir.value.copy(this.lightDir).transformDirection(this.camera.matrixWorldInverse);
+    this.bodyMaterial.uniforms.uTime.value = this.time;
+
+    this.radioGroup.rotation.y = Math.sin(this.time * 0.4) * 0.4;
+    this.radioGroup.rotation.x = Math.sin(this.time * 0.25) * 0.18;
+
+    const cpuStart = performance.now();
+    this.gpuTimer.begin(this.gl);
+    this.renderer.render(this.scene, this.camera);
+    this.gpuTimer.end(this.gl);
+    this.gpuTimer.poll(this.gl);
+    const cpuMs = performance.now() - cpuStart;
+    this.fpsCounter.tick(cpuMs, this.gpuTimer.lastMs);
+  };
+}
+
+export function mountRadio(container: HTMLElement) {
+  container.innerHTML = `
+    <div class="marketing-overlay" aria-label="Radio section: handheld with LCD">
+      <h2>Open-source radio for small robots</h2>
+      <p>Hand-held form factor, dual antenna, LCD screen. Mount it on your bot and stay connected.</p>
+      <p class="template-backend" data-radio-backend aria-live="polite">Rendering: —</p>
+    </div>
+  `;
+
+  const viz = new RadioVisualization(container);
+  return {
+    dispose: () => {
+      viz.dispose();
+      container.innerHTML = "";
+    },
+    setVisible: (visible: boolean) => viz.setVisible(visible),
+  };
+}

--- a/src/plugins/www/app/src/components/radio/README.md
+++ b/src/plugins/www/app/src/components/radio/README.md
@@ -1,0 +1,63 @@
+# Radio component
+
+Three.js section that shows an open-source handheld radio for small robots. Built on the same stack as **threejs-template** (key light, glow shader, FPS, backend label, marketing overlay).
+
+## Location
+
+- **Component:** `../radio.ts` (parent folder)
+- **Section ID:** `s-radio` · **Container:** `#radio-container`
+- **URL hash:** `#s-radio`
+
+## Scene
+
+- **Camera:** Perspective at `(0, 0, 3)` looking at origin.
+- **Background:** Black (`0x000000`).
+- **Animation:** Radio group has a slow oscillation (`rotation.y` and `rotation.x` with sin(time)); lights are fixed.
+
+## Lighting
+
+- **Ambient:** `0xccddff`, intensity `0.55`.
+- **Key (warm):** `0xffddbb`, intensity `1.8`, position `(4, 3, 2.5)` — drives body glow shader `uLightDir`.
+- **Rim (cool):** `0x88aaff`, intensity `1.2`, position `(-2.5, 1, -4)`.
+- **Front:** White, intensity `0.9`, position `(0, 0, 5)` — keeps LCD and knobs visible.
+
+## Model
+
+Built from four groups (all under `radioGroup`):
+
+| Group         | Contents                                      |
+|---------------|-----------------------------------------------|
+| `bodyGroup`   | Single box, custom `ShaderMaterial` (template-cube glow: `uColor` `0x5a6070`, `uGlowColor` `0x88aacc`) |
+| `lcdGroup`    | Plane for LCD; `MeshStandardMaterial` green emissive |
+| `antennasGroup` | Two cylinders (left/right), metal/rough       |
+| `knobsGroup`  | Two cylinders (knobs on front), metal/rough   |
+
+Approximate size: body 1.2×0.6×0.25; LCD 0.5×0.22; antennas ~0.35 tall; knobs on +Z face.
+
+## Shaders
+
+Body uses **template-cube** glow shaders:
+
+- `src/plugins/www/app/src/shaders/template-cube.vert.glsl`
+- `src/plugins/www/app/src/shaders/template-cube.frag.glsl`
+
+Uniforms: `uColor`, `uGlowColor`, `uLightDir` (view space), `uTime`.
+
+## Contract
+
+- **Mount:** `mountRadio(container)` returns `{ dispose, setVisible }`.
+- **Visibility:** Uses `VisibilityMixin`; animation loop skips work when section is off-screen.
+- **UI:** Marketing overlay (heading + copy) and backend label (`data-radio-backend`) for “Rendering: WebGL 2 · WebGPU: …”.
+
+## How to run
+
+```bash
+./dialtone.sh www dev
+# Open http://localhost:<port>/#s-radio
+
+./dialtone.sh www radio demo   # Dev server + Chrome on #s-radio
+```
+
+## Adding to the site
+
+The section is registered in `main.ts` and the container/canvas are styled in `style.css`. See the www plugin README (“Simplest working section”) for the pattern used to add sections like this.

--- a/src/plugins/www/app/src/components/threejs-template.ts
+++ b/src/plugins/www/app/src/components/threejs-template.ts
@@ -1,0 +1,171 @@
+import * as THREE from "three";
+import { FpsCounter } from "./fps";
+import { GpuTimer } from "./gpu_timer";
+import { VisibilityMixin } from "./section";
+import cubeGlowVert from "../shaders/template-cube.vert.glsl?raw";
+import cubeGlowFrag from "../shaders/template-cube.frag.glsl?raw";
+
+/**
+ * Simplest working section: one cube, camera facing it, key light + soft glow shader.
+ * Use this as the starting point for new Three.js sections.
+ */
+
+class TemplateVisualization {
+  scene = new THREE.Scene();
+  camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  container: HTMLElement;
+  frameId = 0;
+  resizeObserver?: ResizeObserver;
+  gl!: WebGLRenderingContext | WebGL2RenderingContext;
+  gpuTimer = new GpuTimer();
+  isVisible = true;
+  private fpsCounter = new FpsCounter("threejs-template");
+  private cube!: THREE.Mesh;
+  private cubeMaterial!: THREE.ShaderMaterial;
+  private keyLight!: THREE.DirectionalLight;
+  private time = 0;
+  private lightDir = new THREE.Vector3(1, 1, 1).normalize();
+  frameCount = 0;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+
+    this.renderer.setClearColor(0x111111, 1);
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+    const canvas = this.renderer.domElement;
+    canvas.style.position = "absolute";
+    canvas.style.top = "0";
+    canvas.style.left = "0";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+
+    const existingCanvas = container.querySelector("canvas");
+    if (existingCanvas) {
+      this.renderer.domElement = existingCanvas as HTMLCanvasElement;
+    } else {
+      this.container.appendChild(canvas);
+    }
+
+    this.camera.position.set(0, 0, 3);
+    this.camera.lookAt(0, 0, 0);
+
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+
+    this.keyLight = new THREE.DirectionalLight(0xffffff, 0.9);
+    this.keyLight.position.set(2, 2, 2);
+    this.scene.add(this.keyLight);
+
+    const cubeGeo = new THREE.BoxGeometry(1, 1, 1);
+    this.cubeMaterial = new THREE.ShaderMaterial({
+      uniforms: {
+        uColor: { value: new THREE.Color(0x6688aa) },
+        uGlowColor: { value: new THREE.Color(0x88aacc) },
+        uLightDir: { value: this.lightDir.clone() },
+        uTime: { value: 0 },
+      },
+      vertexShader: cubeGlowVert,
+      fragmentShader: cubeGlowFrag,
+    });
+    this.cube = new THREE.Mesh(cubeGeo, this.cubeMaterial);
+    this.scene.add(this.cube);
+
+    this.resize();
+    this.animate();
+
+    this.gl = this.renderer.getContext();
+    this.gpuTimer.init(this.gl);
+
+    this.updateBackendLabel();
+
+    if (typeof ResizeObserver !== "undefined") {
+      this.resizeObserver = new ResizeObserver(() => this.resize());
+      this.resizeObserver.observe(this.container);
+    } else {
+      window.addEventListener("resize", this.resize);
+    }
+  }
+
+  resize = () => {
+    const rect = this.container.getBoundingClientRect();
+    const width = Math.max(1, rect.width);
+    const height = Math.max(1, rect.height);
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(width, height, false);
+  };
+
+  dispose() {
+    cancelAnimationFrame(this.frameId);
+    this.resizeObserver?.disconnect();
+    window.removeEventListener("resize", this.resize);
+    this.renderer.dispose();
+    if (this.container.contains(this.renderer.domElement)) {
+      this.container.removeChild(this.renderer.domElement);
+    }
+  }
+
+  setVisible(visible: boolean) {
+    VisibilityMixin.setVisible(this, visible, "threejs-template");
+    if (!visible) this.fpsCounter.clear();
+  }
+
+  private getRenderBackend(): string {
+    if (typeof this.gl === "undefined") return "—";
+    return this.gl instanceof WebGL2RenderingContext ? "WebGL 2" : "WebGL 1";
+  }
+
+  private isWebGPUAvailable(): boolean {
+    return typeof navigator !== "undefined" && "gpu" in navigator;
+  }
+
+  private updateBackendLabel(): void {
+    const el = this.container.querySelector("[data-threejs-template-backend]");
+    if (!el) return;
+    const backend = this.getRenderBackend();
+    const webgpu = this.isWebGPUAvailable();
+    el.textContent = `Rendering: ${backend} · WebGPU: ${webgpu ? "available" : "not available"}`;
+  }
+
+  animate = () => {
+    this.frameId = requestAnimationFrame(this.animate);
+    if (!this.isVisible) return;
+
+    this.time += 0.016;
+    this.frameCount++;
+    this.cube.rotation.x = this.time * 0.3;
+    this.cube.rotation.y = this.time * 0.2;
+
+    this.lightDir.set(1, 1, 1).normalize();
+    this.cubeMaterial.uniforms.uLightDir.value.copy(this.lightDir).transformDirection(this.camera.matrixWorldInverse);
+    this.cubeMaterial.uniforms.uTime.value = this.time;
+
+    const cpuStart = performance.now();
+    this.gpuTimer.begin(this.gl);
+    this.renderer.render(this.scene, this.camera);
+    this.gpuTimer.end(this.gl);
+    this.gpuTimer.poll(this.gl);
+    const cpuMs = performance.now() - cpuStart;
+    this.fpsCounter.tick(cpuMs, this.gpuTimer.lastMs);
+  };
+}
+
+export function mountThreeJsTemplate(container: HTMLElement) {
+  container.innerHTML = `
+    <div class="marketing-overlay" aria-label="Template section: simplest working section">
+      <h2>Start here</h2>
+      <p>The simplest working section—one cube, one camera, one light. Copy this component when you add a new Three.js section to the site.</p>
+      <p class="template-backend" data-threejs-template-backend aria-live="polite">Rendering: —</p>
+    </div>
+  `;
+
+  const viz = new TemplateVisualization(container);
+  return {
+    dispose: () => {
+      viz.dispose();
+      container.innerHTML = "";
+    },
+    setVisible: (visible: boolean) => viz.setVisible(visible),
+  };
+}

--- a/src/plugins/www/app/src/components/webgpu-template.ts
+++ b/src/plugins/www/app/src/components/webgpu-template.ts
@@ -1,6 +1,12 @@
 import { FpsCounter } from "./fps";
 import { VisibilityMixin } from "./section";
 
+/**
+ * WebGPU template: minimal working section using the WebGPU API (no Three.js).
+ * Use this as the starting point for new WebGPU-based sections.
+ * Shows a lit sphere, WGSL shaders, adapter/device/context setup, and dispose/setVisible contract.
+ */
+
 type Mat4 = Float32Array;
 
 const FLOATS_PER_MAT4 = 16;
@@ -231,7 +237,7 @@ class WebGpuVisualization {
   lastTime = performance.now();
   isVisible = true;
   frameCount = 0;
-  private fpsCounter = new FpsCounter("webgpu");
+  private fpsCounter = new FpsCounter("webgpu-template");
 
   uniformData = new Float32Array(UNIFORM_FLOATS);
   model = createMat4();
@@ -465,7 +471,7 @@ class WebGpuVisualization {
   }
 
   setVisible(visible: boolean) {
-    VisibilityMixin.setVisible(this, visible, "webgpu");
+    VisibilityMixin.setVisible(this, visible, "webgpu-template");
     if (!visible) {
       this.fpsCounter.clear();
     }
@@ -502,11 +508,12 @@ class WebGpuVisualization {
   }
 }
 
-export async function mountWebgpu(container: HTMLElement) {
+export async function mountWebgpuTemplate(container: HTMLElement) {
   container.innerHTML = `
-    <div class="marketing-overlay" aria-label="WebGPU visualization marketing information">
-      <h2>WebGPU lighting in motion</h2>
-      <p>Pure WebGPU shading with a rotating light source.</p>
+    <div class="marketing-overlay" aria-label="WebGPU template section">
+      <h2>Start here for WebGPU</h2>
+      <p>The simplest working WebGPU section—adapter, device, context, pipeline, and a lit sphere. Copy this component when you add a new WebGPU section to the site.</p>
+      <p class="template-backend" data-webgpu-template-backend aria-live="polite">Rendering: —</p>
     </div>
   `;
 
@@ -569,6 +576,9 @@ export async function mountWebgpu(container: HTMLElement) {
     context,
     navigator.gpu.getPreferredCanvasFormat(),
   );
+
+  const backendEl = container.querySelector("[data-webgpu-template-backend]");
+  if (backendEl) backendEl.textContent = "Rendering: WebGPU";
 
   return {
     dispose: () => {

--- a/src/plugins/www/app/src/shaders/template-cube.frag.glsl
+++ b/src/plugins/www/app/src/shaders/template-cube.frag.glsl
@@ -1,0 +1,23 @@
+uniform vec3 uColor;
+uniform vec3 uGlowColor;
+uniform vec3 uLightDir;
+uniform float uTime;
+
+varying vec3 vNormal;
+varying vec3 vViewPosition;
+
+void main() {
+  vec3 N = normalize(vNormal);
+  vec3 V = normalize(vViewPosition);
+  vec3 L = normalize(uLightDir);
+
+  float diffuse = max(0.0, dot(N, L));
+  float key = 0.4 + 0.6 * diffuse;
+
+  float fresnel = pow(1.0 - max(0.0, dot(N, V)), 2.0);
+  float glow = fresnel * (0.6 + 0.2 * sin(uTime));
+
+  vec3 lit = uColor * key;
+  vec3 rim = uGlowColor * glow;
+  gl_FragColor = vec4(lit + rim, 1.0);
+}

--- a/src/plugins/www/app/src/shaders/template-cube.vert.glsl
+++ b/src/plugins/www/app/src/shaders/template-cube.vert.glsl
@@ -1,0 +1,9 @@
+varying vec3 vNormal;
+varying vec3 vViewPosition;
+
+void main() {
+  vNormal = normalize(normalMatrix * normal);
+  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+  vViewPosition = -mvPosition.xyz;
+  gl_Position = projectionMatrix * mvPosition;
+}

--- a/src/plugins/www/app/style.css
+++ b/src/plugins/www/app/style.css
@@ -91,7 +91,9 @@ h2 {
 #math-container,
 #cad-container,
 #robot-container,
-#webgpu-container {
+#webgpu-template-container,
+#radio-container,
+#threejs-template-container {
   position: absolute;
   top: 0;
   left: 0;
@@ -104,7 +106,9 @@ h2 {
 #nn-container canvas,
 #math-container canvas,
 #robot-container canvas,
-#webgpu-container canvas {
+#webgpu-template-container canvas,
+#radio-container canvas,
+#threejs-template-container canvas {
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- **Radio section**: Handheld radio (body, LCD, antennas, knobs) with warm/cool lighting, template-cube glow shader, FPS, backend label. CLI: `./dialtone.sh www radio demo` opens `#s-radio`.
- **Three.js template**: New `threejs-template` section (cube + key light + glow) as the reference for new Three.js sections.
- **WebGPU template**: Renamed `webgpu` → `webgpu-template`; docs and CLI aligned.
- **Shaders**: Added `template-cube.vert.glsl` / `template-cube.frag.glsl` for body glow.
- **Radio README**: `src/plugins/www/app/src/components/radio/README.md`.
- **VisibilityMixin**: Added `frameCount` to radio and threejs-template so `setVisible` type checks pass.