### PR TITLE
fix(www): remove cloud oscillation and set presets

### DIFF
--- a/src/plugins/www/app/src/components/about/index.ts
+++ b/src/plugins/www/app/src/components/about/index.ts
@@ -374,25 +374,25 @@ export function mountAbout(container: HTMLElement) {
 
   const viz = new VisionVisualization(container);
   const lightConfig = {
-    count: 4,
-    dwell: 8,
-    wander: 8,
+    count: 6,      // Hot
+    dwell: 5,      // Frenzy
+    wander: 12,    // Frenzy
     seed: 4830,
-    brightness: 1.35,
+    brightness: 2.1, // Hot
   };
   const sparkConfig = {
-    intervalSeconds: 4,
-    pauseMs: 1200,
-    drainRatePerMs: 0.001,
+    intervalSeconds: 1.5, // Storm
+    pauseMs: 700,         // Storm
+    drainRatePerMs: 0.0016, // Storm
   };
   const powerConfig = {
-    maxPower: 5,
-    regenPerSec: 1,
-    restThreshold: 1,
+    maxPower: 7,       // Hot
+    regenPerSec: 1.8,  // Hot
+    restThreshold: 1.4, // Hot
   };
   const motionConfig = {
-    glideSpeed: 7,
-    glideAccel: 8,
+    glideSpeed: 12,   // Frenzy
+    glideAccel: 14,   // Frenzy
   };
   const lifeConfig = {
     stepsPerSecond: 4,

--- a/src/plugins/www/app/src/components/about/menu.ts
+++ b/src/plugins/www/app/src/components/about/menu.ts
@@ -78,9 +78,9 @@ export function setupAboutMenu(options: AboutConfigOptions): () => void {
         { label: "Storm", intervalSeconds: 1.5, pauseMs: 700, drainRatePerMs: 0.0016 },
     ];
 
-    let lightPresetIndex = 1;
-    let motionPresetIndex = 1;
-    let sparkPresetIndex = 1;
+    let lightPresetIndex = 3; // Hot
+    let motionPresetIndex = 3; // Frenzy
+    let sparkPresetIndex = 3; // Storm
     let presetSwapEnabled = 0;
 
     // Sliders references for syncing

--- a/src/plugins/www/app/src/components/earth/index.ts
+++ b/src/plugins/www/app/src/components/earth/index.ts
@@ -117,13 +117,11 @@ export class ProceduralOrbit {
   shaderTimeScale = 0.28;
   timeScale = TIME_SCALE;
   // Clouds: make them more visible by default.
+  // Clouds: make them more visible by default.
   cloudAmount = 1.0;
-  cloudOpacityOscAmp = 0.12;
-  cloudAmountOscAmp = 0.18;
-  cloudOscSpeed = 2.5;
 
   // Rotations
-  earthRotSpeed = (Math.PI * 2) / EARTH_ROT_PERIOD_SECONDS;
+  earthRotSpeed = (Math.PI * 2) / 120; // 120s period (faster)
   cloud1RotSpeed = (Math.PI * 2) / 240;
   cloud2RotSpeed = (Math.PI * 2) / 280;
   cloud1Opacity = 0.95;
@@ -547,20 +545,9 @@ export class ProceduralOrbit {
     this.lastFrameTime = now;
     const deltaSeconds = rawDelta * this.timeScale;
     const cloudTime = now * 0.001 * this.shaderTimeScale;
-    const osc = Math.sin(now * 0.001 * this.cloudOscSpeed);
-    const oscOffset = Math.cos(now * 0.001 * this.cloudOscSpeed * 0.9);
-    const cloudAmount = Math.max(
-      0,
-      Math.min(1, this.cloudAmount + osc * this.cloudAmountOscAmp),
-    );
-    const cloud1Opacity = Math.max(
-      0.5,
-      this.cloud1Opacity + oscOffset * this.cloudOpacityOscAmp,
-    );
-    const cloud2Opacity = Math.max(
-      0.5,
-      this.cloud2Opacity - oscOffset * this.cloudOpacityOscAmp,
-    );
+    const cloudAmount = this.cloudAmount;
+    const cloud1Opacity = this.cloud1Opacity;
+    const cloud2Opacity = this.cloud2Opacity;
 
     // Rotations
     this.earth.rotation.y += this.earthRotSpeed * deltaSeconds;

--- a/src/plugins/www/app/src/shaders/cloud.frag.glsl
+++ b/src/plugins/www/app/src/shaders/cloud.frag.glsl
@@ -86,10 +86,8 @@ void main() {
     // Multi-octave FBM for base density
     float nBase = fbm(vPosition * (CLOUD_SCALE * 0.6) + q * 1.5 + uTime * 0.05);
     
-    // Atmospheric "Breathing" Oscillation
-    float baseThreshold = mix(0.5, -0.1, uCloudAmount);
-    float breath = sin(uTime * 0.12) * 0.06;
-    float threshold = baseThreshold + breath;
+    // Atmospheric Density (Static)
+    float threshold = mix(0.5, -0.1, uCloudAmount);
     float alpha = smoothstep(threshold, threshold + 0.3, nBase) * uOpacity;
 
     vec3 sunDir = normalize(uSunDir);


### PR DESCRIPTION
Removes cloud oscillation/breathing, significantly speeds up Earth rotation (120s), and sets About section defaults to 'Hot Frenzy Storm'.