### PR TITLE
www/earth: improve camera orbit and equator targeting

### DIFF
--- a/src/plugins/www/app/index.html
+++ b/src/plugins/www/app/index.html
@@ -16,7 +16,7 @@
     <header class="header-title">
       <h1>dialtone.earth</h1>
       <p class="version header-fps">FPS --</p>
-      <p class="version">v1.0.54</p>
+      <p class="version">v1.0.55</p>
     </header>
 
     <nav class="main-nav">

--- a/src/plugins/www/app/package-lock.json
+++ b/src/plugins/www/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialtone-www",
-      "version": "1.0.54",
+      "version": "1.0.55",
       "dependencies": {
         "d3": "^7.9.0",
         "h3-js": "^4.4.0",
@@ -1074,6 +1074,7 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1469,6 +1470,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/src/plugins/www/app/package.json
+++ b/src/plugins/www/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary\n- switch Earth camera to a continuous elliptical orbit around the centered x/z plane\n- keep camera outside Earth while varying near/far distance\n- move look target continuously along Earth equator\n- lower orbit height and slow Earth/camera motion for smoother demo\n- include www version bump to v1.0.55 from publish\n\n## Validation\n- npm run build (src/plugins/www/app)\n- ./dialtone.sh www smoke\n- ./dialtone.sh www publish