### PR TITLE
www/earth: fix mirrored H3 land longitude mapping

### DIFF
--- a/src/plugins/www/app/index.html
+++ b/src/plugins/www/app/index.html
@@ -16,7 +16,7 @@
     <header class="header-title">
       <h1>dialtone.earth</h1>
       <p class="version header-fps">FPS --</p>
-      <p class="version">v1.0.55</p>
+      <p class="version">v1.0.56</p>
     </header>
 
     <nav class="main-nav">

--- a/src/plugins/www/app/package-lock.json
+++ b/src/plugins/www/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialtone-www",
-      "version": "1.0.55",
+      "version": "1.0.56",
       "dependencies": {
         "d3": "^7.9.0",
         "h3-js": "^4.4.0",

--- a/src/plugins/www/app/package.json
+++ b/src/plugins/www/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/plugins/www/app/src/components/earth/hex_layer.ts
+++ b/src/plugins/www/app/src/components/earth/hex_layer.ts
@@ -302,7 +302,8 @@ export class HexLayer {
 
   private latLngToVector(lat: number, lng: number, radius: number) {
     const phi = (90 - lat) * DEG_TO_RAD;
-    const theta = (lng + 180) * DEG_TO_RAD;
+    // Negate longitude so west/east map to the expected globe sides in scene space.
+    const theta = (-lng + 180) * DEG_TO_RAD;
     return new THREE.Vector3(
       radius * Math.sin(phi) * Math.cos(theta),
       radius * Math.cos(phi),

--- a/src/plugins/www/app/src/components/geotools/index.ts
+++ b/src/plugins/www/app/src/components/geotools/index.ts
@@ -302,7 +302,8 @@ class GeoToolsVisualization {
 
   private latLngToVector(lat: number, lng: number, radius: number) {
     const phi = (90 - lat) * (Math.PI / 180);
-    const theta = (lng + 180) * (Math.PI / 180);
+    // Negate longitude so west/east map to the expected globe sides in scene space.
+    const theta = (-lng + 180) * (Math.PI / 180);
     return new THREE.Vector3(
       radius * Math.sin(phi) * Math.cos(theta),
       radius * Math.cos(phi),
@@ -463,4 +464,3 @@ export function mountGeoTools(container: HTMLElement) {
     },
   };
 }
-


### PR DESCRIPTION
## Summary\n- fix mirrored west/east mapping by correcting longitude sign in sphere projection\n- apply fix in both GeoTools preview and Earth hex-layer rendering\n- include publish version bump to v1.0.56\n\n## Validation\n- npm run build (src/plugins/www/app)\n- ./dialtone.sh www publish