### PR TITLE
www: per-section header/menu visibility and subtitle/overlay updates

### DIFF
--- a/src/plugins/www/app/index.html
+++ b/src/plugins/www/app/index.html
@@ -16,7 +16,7 @@
     <header class="header-title">
       <h1>dialtone.earth</h1>
       <p class="version header-fps">FPS --</p>
-      <p class="version">v1.0.56</p>
+      <p class="version">v1.0.57</p>
     </header>
 
     <nav class="main-nav">

--- a/src/plugins/www/app/package-lock.json
+++ b/src/plugins/www/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialtone-www",
-      "version": "1.0.56",
+      "version": "1.0.57",
       "dependencies": {
         "d3": "^7.9.0",
         "h3-js": "^4.4.0",

--- a/src/plugins/www/app/package.json
+++ b/src/plugins/www/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/plugins/www/app/src/components/earth/hex_layer.ts
+++ b/src/plugins/www/app/src/components/earth/hex_layer.ts
@@ -301,13 +301,12 @@ export class HexLayer {
   }
 
   private latLngToVector(lat: number, lng: number, radius: number) {
-    const phi = (90 - lat) * DEG_TO_RAD;
-    // Negate longitude so west/east map to the expected globe sides in scene space.
-    const theta = (-lng + 180) * DEG_TO_RAD;
+    const latRad = lat * DEG_TO_RAD;
+    const lngRad = lng * DEG_TO_RAD;
     return new THREE.Vector3(
-      radius * Math.sin(phi) * Math.cos(theta),
-      radius * Math.cos(phi),
-      radius * Math.sin(phi) * Math.sin(theta),
+      radius * Math.cos(latRad) * Math.sin(lngRad),
+      radius * Math.sin(latRad),
+      radius * Math.cos(latRad) * Math.cos(lngRad),
     );
   }
 }

--- a/src/plugins/www/app/src/components/geotools/index.ts
+++ b/src/plugins/www/app/src/components/geotools/index.ts
@@ -301,13 +301,12 @@ class GeoToolsVisualization {
   }
 
   private latLngToVector(lat: number, lng: number, radius: number) {
-    const phi = (90 - lat) * (Math.PI / 180);
-    // Negate longitude so west/east map to the expected globe sides in scene space.
-    const theta = (-lng + 180) * (Math.PI / 180);
+    const latRad = lat * (Math.PI / 180);
+    const lngRad = lng * (Math.PI / 180);
     return new THREE.Vector3(
-      radius * Math.sin(phi) * Math.cos(theta),
-      radius * Math.cos(phi),
-      radius * Math.sin(phi) * Math.sin(theta),
+      radius * Math.cos(latRad) * Math.sin(lngRad),
+      radius * Math.sin(latRad),
+      radius * Math.cos(latRad) * Math.cos(lngRad),
     );
   }
 }

--- a/src/plugins/www/app/src/components/robot/index.ts
+++ b/src/plugins/www/app/src/components/robot/index.ts
@@ -650,6 +650,8 @@ export function mountRobot(container: HTMLElement) {
   <div class="marketing-overlay" aria-label="Robot visualization marketing information">
     <h2>Robotic Control</h2>
     <p data-typing-subtitle></p>
+  </div>
+  <div class="robot-buy-cta">
     <a class="buy-button" href="https://buy.stripe.com/test_5kQaEXcagaAoaC62N20kE00" target="_blank"
       rel="noopener noreferrer">Get the Robot Kit</a>
   </div>

--- a/src/plugins/www/app/src/components/util/typing.ts
+++ b/src/plugins/www/app/src/components/util/typing.ts
@@ -1,46 +1,32 @@
 export function startTyping(
   subtitleEl: HTMLParagraphElement | null,
   subtitles: string[],
-  options: { typeMs?: number; holdMs?: number; fadeMs?: number } = {}
+  options: { holdMs?: number; fadeMs?: number } = {}
 ) {
   if (!subtitleEl || subtitles.length === 0) {
     return () => {};
   }
-  const typeMs = options.typeMs ?? 42;
-  const holdMs = options.holdMs ?? 6000;
-  const fadeMs = options.fadeMs ?? 1200;
+  const holdMs = options.holdMs ?? 5000;
+  const fadeMs = options.fadeMs ?? 250;
   let index = 0;
-  let charIndex = 0;
-  let typingTimer: number | undefined;
-  let typingTimeout: number | undefined;
+  let swapTimer: number | undefined;
+  let fadeTimer: number | undefined;
   subtitleEl.style.opacity = "1";
   subtitleEl.style.transition = `opacity ${fadeMs}ms ease`;
+  subtitleEl.textContent = subtitles[index];
 
-  const step = () => {
-    const full = subtitles[index];
-    const next = full.slice(0, Math.min(full.length, charIndex + 1));
-    subtitleEl.textContent = `| ${next || "\u00A0"}`;
-    charIndex += 1;
-    if (charIndex >= full.length) {
-      typingTimeout = window.setTimeout(() => {
-        subtitleEl.style.opacity = "0";
-        typingTimeout = window.setTimeout(() => {
-          index = (index + 1) % subtitles.length;
-          charIndex = 0;
-          subtitleEl.textContent = "| \u00A0";
-          subtitleEl.style.opacity = "1";
-          step();
-        }, fadeMs);
-      }, holdMs);
-      return;
-    }
-    typingTimer = window.setTimeout(step, typeMs);
+  const swap = () => {
+    subtitleEl.style.opacity = "0";
+    fadeTimer = window.setTimeout(() => {
+      index = (index + 1) % subtitles.length;
+      subtitleEl.textContent = subtitles[index];
+      subtitleEl.style.opacity = "1";
+    }, fadeMs);
   };
-
-  step();
+  swapTimer = window.setInterval(swap, holdMs);
 
   return () => {
-    if (typingTimer) window.clearTimeout(typingTimer);
-    if (typingTimeout) window.clearTimeout(typingTimeout);
+    if (swapTimer) window.clearInterval(swapTimer);
+    if (fadeTimer) window.clearTimeout(fadeTimer);
   };
 }

--- a/src/plugins/www/app/style.css
+++ b/src/plugins/www/app/style.css
@@ -170,6 +170,7 @@ h2 {
   pointer-events: auto;
 }
 
+/* Keep the top-left "dialtone.earth" header hidden on all sections. */
 .main-nav {
   position: fixed;
   bottom: 1.5rem;
@@ -834,14 +835,12 @@ h2 {
   font-weight: 500;
   letter-spacing: 0.02em;
   cursor: pointer;
-  display: none;
-  /* Hidden by default, shown via JS/CSS when section active */
+  display: inline-block;
   transition: all 0.2s ease;
 }
 
-/* Show toggle when section is active */
-.snap-slide.is-visible~.top-right-controls .menu-toggle {
-  display: inline-block;
+.menu-toggle.is-hidden {
+  display: none !important;
 }
 
 .menu-toggle:hover {
@@ -1000,6 +999,11 @@ h2 {
   .marketing-overlay p {
     font-size: clamp(1rem, 1.3vw, 1.5rem);
   }
+
+  .robot-buy-cta {
+    bottom: 1.25rem;
+    padding: 0 1rem;
+  }
 }
 
 .snap-slide.is-visible .marketing-overlay {
@@ -1011,6 +1015,7 @@ h2 {
   font-size: clamp(2.25rem, 3vw + 0.5rem, 3.75rem);
   font-weight: 700;
   color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
   letter-spacing: -0.02em;
   max-width: 800px;
   margin: 0;
@@ -1020,6 +1025,7 @@ h2 {
   font-size: 1.25rem;
   line-height: 1.5;
   color: rgba(255, 255, 255, 0.8);
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.55);
   max-width: 600px;
   /* Fixed height for 3 lines of text (approx 1.5 * 3 = 4.5rem) to prevent jumping */
   min-height: 4.5em;
@@ -1066,6 +1072,21 @@ h2 {
 .buy-button:hover {
   transform: translateY(-2px);
   box-shadow: 0 16px 36px rgba(99, 91, 255, 0.45);
+}
+
+.robot-buy-cta {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 2.25rem;
+  z-index: 25;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.robot-buy-cta .buy-button {
+  pointer-events: auto;
 }
 
 /* Specific for robot kit in stripe section */


### PR DESCRIPTION
## Summary\n- add per-section menu visibility config independent from header config\n- default header hidden in SectionManager unless explicitly enabled\n- keep menu toggle visibility controlled by TS state ()\n- replace typing animation with 5s subtitle swaps\n- add subtle black marketing text drop shadow\n- move robot buy CTA to bottom of section\n- fix geotools/earth hex lat/lng globe projection orientation\n- include publish version bump to v1.0.57\n\n## Validation\n- npm run build (src/plugins/www/app)\n- ./dialtone.sh www smoke\n- ./dialtone.sh www publish