### PR TITLE
www: policy simulator scenarios, bimodal markers, and histogram UX overhaul

### DIFF
--- a/src/plugins/www/app/bun.lock
+++ b/src/plugins/www/app/bun.lock
@@ -1,0 +1,315 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "dialtone-www",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "h3-js": "^4.4.0",
+        "three": "^0.182.0",
+        "tinygesture": "^3.0.0",
+        "topojson-client": "^3.1.0",
+      },
+      "devDependencies": {
+        "@types/d3": "^7.4.3",
+        "@types/node": "^20.12.7",
+        "@types/three": "^0.182.0",
+        "@types/topojson-client": "^3.1.4",
+        "typescript": "^5.9.3",
+        "vite": "^5.2.0",
+      },
+    },
+  },
+  "packages": {
+    "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.55.2", "", { "os": "android", "cpu": "arm" }, "sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.55.2", "", { "os": "android", "cpu": "arm64" }, "sha512-eXBg7ibkNUZ+sTwbFiDKou0BAckeV6kIigK7y5Ko4mB/5A1KLhuzEKovsmfvsL8mQorkoincMFGnQuIT92SKqA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.55.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UCbaTklREjrc5U47ypLulAgg4njaqfOVLU18VrCrI+6E5MQjuG0lSWaqLlAJwsD7NpFV249XgB0Bi37Zh5Sz4g=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.55.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-dP67MA0cCMHFT2g5XyjtpVOtp7y4UyUxN3dhLdt11at5cPKnSm4lY+EhwNvDXIMzAMIo2KU+mc9wxaAQJTn7sQ=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.55.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-WDUPLUwfYV9G1yxNRJdXcvISW15mpvod1Wv3ok+Ws93w1HjIVmCIFxsG2DquO+3usMNCpJQ0wqO+3GhFdl6Fow=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.55.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Ng95wtHVEulRwn7R0tMrlUuiLVL/HXA8Lt/MYVpy88+s5ikpntzZba1qEulTuPnPIZuOPcW9wNEiqvZxZmgmqQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.55.2", "", { "os": "linux", "cpu": "arm" }, "sha512-AEXMESUDWWGqD6LwO/HkqCZgUE1VCJ1OhbvYGsfqX2Y6w5quSXuyoy/Fg3nRqiwro+cJYFxiw5v4kB2ZDLhxrw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.55.2", "", { "os": "linux", "cpu": "arm" }, "sha512-ZV7EljjBDwBBBSv570VWj0hiNTdHt9uGznDtznBB4Caj3ch5rgD4I2K1GQrtbvJ/QiB+663lLgOdcADMNVC29Q=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.55.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-uvjwc8NtQVPAJtq4Tt7Q49FOodjfbf6NpqXyW/rjXoV+iZ3EJAHLNAnKT5UJBc6ffQVgmXTUL2ifYiLABlGFqA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.55.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-s3KoWVNnye9mm/2WpOZ3JeUiediUVw6AvY/H7jNA6qgKA2V2aM25lMkVarTDfiicn/DLq3O0a81jncXszoyCFA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.55.2", "", { "os": "linux", "cpu": "none" }, "sha512-gi21faacK+J8aVSyAUptML9VQN26JRxe484IbF+h3hpG+sNVoMXPduhREz2CcYr5my0NE3MjVvQ5bMKX71pfVA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.55.2", "", { "os": "linux", "cpu": "none" }, "sha512-qSlWiXnVaS/ceqXNfnoFZh4IiCA0EwvCivivTGbEu1qv2o+WTHpn1zNmCTAoOG5QaVr2/yhCoLScQtc/7RxshA=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.55.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-rPyuLFNoF1B0+wolH277E780NUKf+KoEDb3OyoLbAO18BbeKi++YN6gC/zuJoPPDlQRL3fIxHxCxVEWiem2yXw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.55.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-g+0ZLMook31iWV4PvqKU0i9E78gaZgYpSrYPed/4Bu+nGTgfOPtfs1h11tSSRPXSjC5EzLTjV/1A7L2Vr8pJoQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.55.2", "", { "os": "linux", "cpu": "none" }, "sha512-i+sGeRGsjKZcQRh3BRfpLsM3LX3bi4AoEVqmGDyc50L6KfYsN45wVCSz70iQMwPWr3E5opSiLOwsC9WB4/1pqg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.55.2", "", { "os": "linux", "cpu": "none" }, "sha512-C1vLcKc4MfFV6I0aWsC7B2Y9QcsiEcvKkfxprwkPfLaN8hQf0/fKHwSF2lcYzA9g4imqnhic729VB9Fo70HO3Q=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.55.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-68gHUK/howpQjh7g7hlD9DvTTt4sNLp1Bb+Yzw2Ki0xvscm2cOdCLZNJNhd2jW8lsTPrHAHuF751BygifW4bkQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.55.2", "", { "os": "linux", "cpu": "x64" }, "sha512-1e30XAuaBP1MAizaOBApsgeGZge2/Byd6wV4a8oa6jPdHELbRHBiw7wvo4dp7Ie2PE8TZT4pj9RLGZv9N4qwlw=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.55.2", "", { "os": "linux", "cpu": "x64" }, "sha512-4BJucJBGbuGnH6q7kpPqGJGzZnYrpAzRd60HQSt3OpX/6/YVgSsJnNzR8Ot74io50SeVT4CtCWe/RYIAymFPwA=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.55.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cT2MmXySMo58ENv8p6/O6wI/h/gLnD3D6JoajwXFZH6X9jz4hARqUhWpGuQhOgLNXscfZYRQMJvZDtWNzMAIDw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.55.2", "", { "os": "none", "cpu": "arm64" }, "sha512-sZnyUgGkuzIXaK3jNMPmUIyJrxu/PjmATQrocpGA1WbCPX8H5tfGgRSuYtqBYAvLuIGp8SPRb1O4d1Fkb5fXaQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.55.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-sDpFbenhmWjNcEbBcoTV0PWvW5rPJFvu+P7XoTY0YLGRupgLbFY0XPfwIbJOObzO7QgkRDANh65RjhPmgSaAjQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.55.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-GvJ03TqqaweWCigtKQVBErw2bEhu1tyfNQbarwr94wCGnczA9HF8wqEe3U/Lfu6EdeNP0p6R+APeHVwEqVxpUQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.55.2", "", { "os": "win32", "cpu": "x64" }, "sha512-KvXsBvp13oZz9JGe5NYS7FNizLe99Ny+W8ETsuCyjXiKdiGrcz2/J/N8qxZ/RSwivqjQguug07NLHqrIHrqfYw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.2", "", { "os": "win32", "cpu": "x64" }, "sha512-xNO+fksQhsAckRtDSPWaMeT1uIM+JrDRXlerpnWNXhn1TdB3YZ6uKBMBTKP0eX9XtYEP978hHk1f8332i2AW8Q=="],
+
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
+
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.182.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.22.0" } }, "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q=="],
+
+    "@types/topojson-client": ["@types/topojson-client@3.1.5", "", { "dependencies": { "@types/geojson": "*", "@types/topojson-specification": "*" } }, "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw=="],
+
+    "@types/topojson-specification": ["@types/topojson-specification@1.0.5", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
+
+    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
+
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": "bin/esbuild" }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "h3-js": ["h3-js@4.4.0", "", {}, "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "meshoptimizer": ["meshoptimizer@0.22.0", "", {}, "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
+
+    "rollup": ["rollup@4.55.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.2", "@rollup/rollup-android-arm64": "4.55.2", "@rollup/rollup-darwin-arm64": "4.55.2", "@rollup/rollup-darwin-x64": "4.55.2", "@rollup/rollup-freebsd-arm64": "4.55.2", "@rollup/rollup-freebsd-x64": "4.55.2", "@rollup/rollup-linux-arm-gnueabihf": "4.55.2", "@rollup/rollup-linux-arm-musleabihf": "4.55.2", "@rollup/rollup-linux-arm64-gnu": "4.55.2", "@rollup/rollup-linux-arm64-musl": "4.55.2", "@rollup/rollup-linux-loong64-gnu": "4.55.2", "@rollup/rollup-linux-loong64-musl": "4.55.2", "@rollup/rollup-linux-ppc64-gnu": "4.55.2", "@rollup/rollup-linux-ppc64-musl": "4.55.2", "@rollup/rollup-linux-riscv64-gnu": "4.55.2", "@rollup/rollup-linux-riscv64-musl": "4.55.2", "@rollup/rollup-linux-s390x-gnu": "4.55.2", "@rollup/rollup-linux-x64-gnu": "4.55.2", "@rollup/rollup-linux-x64-musl": "4.55.2", "@rollup/rollup-openbsd-x64": "4.55.2", "@rollup/rollup-openharmony-arm64": "4.55.2", "@rollup/rollup-win32-arm64-msvc": "4.55.2", "@rollup/rollup-win32-ia32-msvc": "4.55.2", "@rollup/rollup-win32-x64-gnu": "4.55.2", "@rollup/rollup-win32-x64-msvc": "4.55.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "three": ["three@0.182.0", "", {}, "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="],
+
+    "tinygesture": ["tinygesture@3.0.0", "", {}, "sha512-UawUggtPCHy+N65ULpR/i6VLH8AzB7jWVvTNoXRFTJNh+ub6lP/SJCxzV/Ua7sJbCt9U9I79wKkKk3wbjcLdbQ=="],
+
+    "topojson-client": ["topojson-client@3.1.0", "", { "dependencies": { "commander": "2" }, "bin": { "topo2geo": "bin/topo2geo", "topomerge": "bin/topomerge", "topoquantize": "bin/topoquantize" } }, "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": "bin/vite.js" }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+  }
+}

--- a/src/plugins/www/app/index.html
+++ b/src/plugins/www/app/index.html
@@ -16,7 +16,7 @@
     <header class="header-title">
       <h1>dialtone.earth</h1>
       <p class="version header-fps">FPS --</p>
-      <p class="version">v1.0.64</p>
+      <p class="version">v1.0.65</p>
     </header>
 
     <nav class="main-nav">

--- a/src/plugins/www/app/package-lock.json
+++ b/src/plugins/www/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialtone-www",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "d3": "^7.9.0",
         "h3-js": "^4.4.0",
@@ -1075,6 +1075,7 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1470,6 +1471,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/src/plugins/www/app/package.json
+++ b/src/plugins/www/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialtone-www",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/plugins/www/app/src/components/policy/histogram.ts
+++ b/src/plugins/www/app/src/components/policy/histogram.ts
@@ -1,0 +1,269 @@
+import * as THREE from "three";
+
+export interface HistogramMeta {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+  mean: number;
+  meanA: number;
+  meanB: number;
+  bimodal: boolean;
+  breakEvenX: number;
+  p10: number;
+  p90: number;
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+function formatMillions(value: number): string {
+  return `${(value / 1e6).toFixed(2)}M`;
+}
+
+function formatUsdMillions(value: number): string {
+  const millions = value / 1e6;
+  return `$${millions.toFixed(1)}M`;
+}
+
+export class PolicyHistogram {
+  group = new THREE.Group();
+  private bars: THREE.LineSegments[] = [];
+  private barCount: number;
+  private maxHeight: number;
+  private chartWidth: number;
+  private baseline: THREE.Line;
+  private yAxis: THREE.Line;
+  private meanLine: THREE.Line;
+  private meanLineB: THREE.Line;
+  private p10Line: THREE.Line;
+  private p90Line: THREE.Line;
+  private breakEvenLine: THREE.Line;
+  private xMinLabel: THREE.Sprite;
+  private xMaxLabel: THREE.Sprite;
+  private p10Label: THREE.Sprite;
+  private meanLabel: THREE.Sprite;
+  private p90Label: THREE.Sprite;
+  private breakEvenLabel: THREE.Sprite;
+  private simCountLabel: THREE.Sprite;
+  private currentMeanX = 0;
+  private currentMeanBX = 0;
+  private currentP10X = 0;
+  private currentP90X = 0;
+  private currentBreakEvenX = 0;
+  private smoothedValues: number[] = [];
+
+  constructor(barCount = 28, maxHeight = 2.8) {
+    this.barCount = barCount;
+    this.maxHeight = maxHeight;
+
+    const spacing = 0.16;
+    const width = 0.11;
+    this.chartWidth = (this.barCount - 1) * spacing;
+
+    for (let i = 0; i < this.barCount; i++) {
+      const boxGeometry = new THREE.BoxGeometry(width, 1, width);
+      boxGeometry.translate(0, 0.5, 0);
+      const edges = new THREE.EdgesGeometry(boxGeometry);
+      boxGeometry.dispose();
+      const material = new THREE.LineBasicMaterial({
+        color: 0xf5f5f5,
+        transparent: true,
+        opacity: 0.62,
+      });
+
+      const bar = new THREE.LineSegments(edges, material);
+      const x = (i - (this.barCount - 1) / 2) * spacing;
+      bar.position.set(x, 0, 0);
+      bar.scale.y = 0.01;
+      this.bars.push(bar);
+      this.group.add(bar);
+    }
+
+    this.baseline = this.makeLine(0xa3a3a3, 0.65);
+    this.yAxis = this.makeLine(0xa3a3a3, 0.65);
+    this.meanLine = this.makeLine(0xff4d4d, 0.95);
+    this.meanLineB = this.makeLine(0xff4d4d, 0.95);
+    this.p10Line = this.makeLine(0xd4d4d4, 0.55);
+    this.p90Line = this.makeLine(0xd4d4d4, 0.55);
+    this.breakEvenLine = this.makeLine(0xe5e5e5, 0.65);
+
+    this.group.add(this.baseline, this.yAxis, this.meanLine, this.meanLineB, this.p10Line, this.p90Line, this.breakEvenLine);
+
+    this.xMinLabel = this.makeLabel();
+    this.xMaxLabel = this.makeLabel();
+    this.p10Label = this.makeLabel();
+    this.meanLabel = this.makeLabel();
+    this.p90Label = this.makeLabel();
+    this.breakEvenLabel = this.makeLabel();
+    this.simCountLabel = this.makeLabel();
+
+    this.group.add(this.xMinLabel, this.xMaxLabel, this.p10Label, this.meanLabel, this.p90Label, this.breakEvenLabel, this.simCountLabel);
+    this.xMinLabel.scale.set(1.45, 0.42, 1);
+    this.xMaxLabel.scale.set(1.45, 0.42, 1);
+
+    this.setLinePoints(this.baseline, -this.chartWidth / 2, 0, this.chartWidth / 2, 0);
+    this.setLinePoints(this.yAxis, -this.chartWidth / 2, 0, -this.chartWidth / 2, this.maxHeight);
+    this.currentMeanX = 0;
+    this.currentMeanBX = 0;
+    this.currentP10X = -this.chartWidth * 0.2;
+    this.currentP90X = this.chartWidth * 0.2;
+    this.currentBreakEvenX = 0;
+    this.smoothedValues = Array.from({ length: this.barCount }, () => 0);
+
+    this.updateAxisLabels({
+      xMin: 0,
+      xMax: 1,
+      yMin: 0,
+      yMax: 1,
+      mean: 0,
+      meanA: 0,
+      meanB: 0,
+      bimodal: false,
+      breakEvenX: 0,
+      p10: 0.1,
+      p90: 0.9,
+    });
+    this.setLabel(this.simCountLabel, "Simulations 0");
+    this.simCountLabel.position.set(0, -1.36, 0.05);
+    this.simCountLabel.scale.set(2.25, 0.58, 1);
+  }
+
+  private makeLine(color: number, opacity: number): THREE.Line {
+    const geom = new THREE.BufferGeometry();
+    const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity });
+    return new THREE.Line(geom, mat);
+  }
+
+  private setLinePoints(line: THREE.Line, x0: number, y0: number, x1: number, y1: number): void {
+    (line.geometry as THREE.BufferGeometry).setFromPoints([
+      new THREE.Vector3(x0, y0, 0),
+      new THREE.Vector3(x1, y1, 0),
+    ]);
+  }
+
+  private makeLabel(): THREE.Sprite {
+    const canvas = document.createElement("canvas");
+    canvas.width = 384;
+    canvas.height = 96;
+    const tex = new THREE.CanvasTexture(canvas);
+    const mat = new THREE.SpriteMaterial({
+      map: tex,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+      opacity: 0.95,
+    });
+    const sprite = new THREE.Sprite(mat);
+    sprite.scale.set(1.8, 0.45, 1);
+    return sprite;
+  }
+
+  private setLabel(sprite: THREE.Sprite, text: string): void {
+    const map = (sprite.material as THREE.SpriteMaterial).map;
+    if (!map) return;
+    const canvas = map.image as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "bold 32px Arial";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.shadowColor = "rgba(255, 255, 255, 0.55)";
+    ctx.shadowBlur = 12;
+    ctx.fillText(text, canvas.width / 2, canvas.height / 2 + 1);
+    map.needsUpdate = true;
+  }
+
+  setVisible(visible: boolean): void {
+    this.group.visible = visible;
+  }
+
+  private updateAxisLabels(meta: HistogramMeta): void {
+    this.setLabel(this.xMinLabel, `Min ${formatUsdMillions(meta.xMin)}`);
+    this.setLabel(this.xMaxLabel, `Max ${formatUsdMillions(meta.xMax)}`);
+    this.setLabel(this.p10Label, `P10 ${formatMillions(meta.p10)}`);
+    this.setLabel(this.meanLabel, `Mean ${formatMillions(meta.mean)}`);
+    this.setLabel(this.p90Label, `P90 ${formatMillions(meta.p90)}`);
+    this.setLabel(this.breakEvenLabel, "0");
+
+    this.xMinLabel.position.set(-this.chartWidth / 2 - 0.72, 0.22, 0.05);
+    this.xMaxLabel.position.set(this.chartWidth / 2 + 0.72, 0.22, 0.05);
+    this.p10Label.position.set(this.currentP10X, -1.16, 0.05);
+    this.meanLabel.position.set(this.currentMeanX, -0.86, 0.05);
+    this.p90Label.position.set(this.currentP90X, -1.16, 0.05);
+    this.breakEvenLabel.position.set(this.currentBreakEvenX, -1.44, 0.05);
+  }
+
+  update(values: number[], meta: HistogramMeta, simulationCount = 0): void {
+    for (let i = 0; i < this.bars.length; i++) {
+      const v = values[i] ?? 0;
+      this.smoothedValues[i] = THREE.MathUtils.lerp(this.smoothedValues[i], clamp01(v), 0.16);
+      const targetHeight = 0.03 + Math.pow(this.smoothedValues[i], 1.05) * this.maxHeight;
+      const bar = this.bars[i];
+      bar.scale.y = THREE.MathUtils.lerp(bar.scale.y, targetHeight, 0.22);
+      const mat = bar.material as THREE.LineBasicMaterial;
+      mat.opacity = 0.28 + this.smoothedValues[i] * 0.7;
+    }
+
+    const denom = Math.max(1e-6, meta.xMax - meta.xMin);
+    const meanTarget = -this.chartWidth / 2 + clamp01((meta.meanA - meta.xMin) / denom) * this.chartWidth;
+    const meanBTarget = -this.chartWidth / 2 + clamp01((meta.meanB - meta.xMin) / denom) * this.chartWidth;
+    const p10Target = -this.chartWidth / 2 + clamp01((meta.p10 - meta.xMin) / denom) * this.chartWidth;
+    const p90Target = -this.chartWidth / 2 + clamp01((meta.p90 - meta.xMin) / denom) * this.chartWidth;
+    const breakEvenTarget = -this.chartWidth / 2 + clamp01((meta.breakEvenX - meta.xMin) / denom) * this.chartWidth;
+
+    this.currentMeanX = THREE.MathUtils.lerp(this.currentMeanX, meanTarget, 0.14);
+    this.currentMeanBX = THREE.MathUtils.lerp(this.currentMeanBX, meanBTarget, 0.14);
+    this.currentP10X = THREE.MathUtils.lerp(this.currentP10X, p10Target, 0.14);
+    this.currentP90X = THREE.MathUtils.lerp(this.currentP90X, p90Target, 0.14);
+    this.currentBreakEvenX = THREE.MathUtils.lerp(this.currentBreakEvenX, breakEvenTarget, 0.14);
+
+    this.setLinePoints(this.meanLine, this.currentMeanX, 0, this.currentMeanX, this.maxHeight);
+    this.setLinePoints(this.meanLineB, this.currentMeanBX, 0, this.currentMeanBX, this.maxHeight);
+    this.setLinePoints(this.p10Line, this.currentP10X, 0, this.currentP10X, this.maxHeight);
+    this.setLinePoints(this.p90Line, this.currentP90X, 0, this.currentP90X, this.maxHeight);
+    this.setLinePoints(this.breakEvenLine, this.currentBreakEvenX, 0, this.currentBreakEvenX, this.maxHeight);
+
+    this.meanLineB.visible = meta.bimodal;
+    if (!meta.bimodal) {
+      this.currentMeanBX = this.currentMeanX;
+    }
+
+    this.updateAxisLabels(meta);
+    this.setLabel(this.simCountLabel, `Simulations ${simulationCount.toLocaleString()}`);
+    this.simCountLabel.position.set(0, -0.32, 0.05);
+    this.simCountLabel.scale.set(2.9, 0.72, 1);
+  }
+
+  dispose(): void {
+    for (const bar of this.bars) {
+      bar.geometry.dispose();
+      (bar.material as THREE.Material).dispose();
+    }
+
+    const lines = [this.baseline, this.yAxis, this.meanLine, this.meanLineB, this.p10Line, this.p90Line, this.breakEvenLine];
+    for (const line of lines) {
+      line.geometry.dispose();
+      (line.material as THREE.Material).dispose();
+    }
+
+    const labels = [
+      this.xMinLabel,
+      this.xMaxLabel,
+      this.p10Label,
+      this.meanLabel,
+      this.p90Label,
+      this.breakEvenLabel,
+      this.simCountLabel,
+    ];
+    for (const label of labels) {
+      const mat = label.material as THREE.SpriteMaterial;
+      mat.map?.dispose();
+      mat.dispose();
+    }
+  }
+}

--- a/src/plugins/www/app/src/components/policy/index.ts
+++ b/src/plugins/www/app/src/components/policy/index.ts
@@ -4,17 +4,165 @@ import { GpuTimer } from "../util/gpu_timer";
 import { VisibilityMixin } from "../util/section";
 import { startTyping } from "../util/typing";
 import { setupPolicyMenu } from "./menu";
+import { PolicyHistogram } from "./histogram";
+import type { HistogramMeta } from "./histogram";
+import { MarkovChainModel } from "./markov_chain_model";
+import { MonteCarloModel } from "./monte_carlo_model";
+import { ShadowCostModel } from "./shadow_cost_model";
+import { runPolicyModelTests } from "./model_tests";
+import type { MonteCarloParams, PolicyDomain, PolicyPreset } from "./types";
 
-// Policy domains with positions spread across a sphere
-const POLICY_DOMAINS = [
-  { name: "Energy",         lat: 40,  lng: -100, color: 0xf59e0b, connections: [1, 4, 6] },
-  { name: "Water",          lat: 10,  lng: -60,  color: 0x3b82f6, connections: [0, 5, 7] },
-  { name: "Health",         lat: 50,  lng: 10,   color: 0xef4444, connections: [3, 5, 7] },
-  { name: "Education",      lat: 30,  lng: 80,   color: 0x8b5cf6, connections: [2, 6, 7] },
-  { name: "Infrastructure", lat: -20, lng: -30,  color: 0x10b981, connections: [0, 1, 6] },
-  { name: "Agriculture",    lat: -10, lng: 40,   color: 0x22d3ee, connections: [1, 2, 7] },
-  { name: "Climate",        lat: -40, lng: 120,  color: 0x06b6d4, connections: [0, 3, 4] },
-  { name: "Transport",      lat: -30, lng: -120, color: 0xfbbf24, connections: [2, 3, 5] },
+type ChildNodeDef = { parentIdx: number; names: string[] };
+type PolicyScenario = {
+  id: string;
+  domains: PolicyDomain[];
+  childDefs: ChildNodeDef[];
+};
+
+const POLICY_SCENARIOS: Record<string, PolicyScenario> = {
+  "ev-charging": {
+    id: "ev-charging",
+    domains: [
+      { id: "ev-plan", name: "EV Planning", lat: 43, lng: -95, color: 0xf59e0b, connections: [1, 7], connectionWeights: [0.75, 0.25] },
+      { id: "charger-rollout", name: "Charger Rollout", lat: 18, lng: -55, color: 0x22d3ee, connections: [2, 3], connectionWeights: [0.48, 0.52] },
+      { id: "grid-strain", name: "Grid Strain", lat: 49, lng: 15, color: 0xef4444, connections: [4, 7], connectionWeights: [0.7, 0.3] },
+      { id: "storage-upgrade", name: "Storage Upgrade", lat: 30, lng: 78, color: 0x3b82f6, connections: [4, 5], connectionWeights: [0.58, 0.42] },
+      { id: "fleet-adoption", name: "Fleet Adoption", lat: -15, lng: -35, color: 0x10b981, connections: [5, 6], connectionWeights: [0.55, 0.45] },
+      { id: "rural-access", name: "Rural Access", lat: -9, lng: 42, color: 0x8b5cf6, connections: [6, 7], connectionWeights: [0.66, 0.34] },
+      { id: "emissions-drop", name: "Emissions Drop", lat: -38, lng: 118, color: 0x06b6d4, connections: [6, 4], connectionWeights: [0.72, 0.28] },
+      { id: "policy-stall", name: "Policy Stall", lat: -31, lng: -122, color: 0x64748b, connections: [7, 1], connectionWeights: [0.78, 0.22] },
+    ],
+    childDefs: [
+      { parentIdx: 1, names: ["Depot Fast DC", "Street L2"] },
+      { parentIdx: 3, names: ["Battery Peakers", "Smart Tariffs"] },
+      { parentIdx: 4, names: ["Bus Fleets", "Delivery Vans"] },
+    ],
+  },
+  "childhood-education": {
+    id: "childhood-education",
+    domains: [
+      { id: "screening", name: "Early Screening", lat: 44, lng: -98, color: 0xfbbf24, connections: [1, 7], connectionWeights: [0.7, 0.3] },
+      { id: "teacher", name: "Teacher Pipeline", lat: 14, lng: -62, color: 0x3b82f6, connections: [2, 3], connectionWeights: [0.6, 0.4] },
+      { id: "quality", name: "Classroom Quality", lat: 52, lng: 10, color: 0x8b5cf6, connections: [3, 4], connectionWeights: [0.52, 0.48] },
+      { id: "attendance", name: "Attendance Gains", lat: 28, lng: 82, color: 0x22c55e, connections: [4, 5], connectionWeights: [0.65, 0.35] },
+      { id: "parent", name: "Parent Support", lat: -18, lng: -28, color: 0x10b981, connections: [5, 6], connectionWeights: [0.62, 0.38] },
+      { id: "nutrition", name: "School Nutrition", lat: -8, lng: 35, color: 0x06b6d4, connections: [6, 7], connectionWeights: [0.68, 0.32] },
+      { id: "graduation", name: "Graduation Lift", lat: -36, lng: 116, color: 0x2dd4bf, connections: [6, 4], connectionWeights: [0.75, 0.25] },
+      { id: "dropout", name: "Dropout Risk", lat: -30, lng: -118, color: 0xef4444, connections: [7, 2], connectionWeights: [0.8, 0.2] },
+    ],
+    childDefs: [
+      { parentIdx: 1, names: ["Residency", "Mentorship"] },
+      { parentIdx: 4, names: ["Home Visits", "Care Access"] },
+      { parentIdx: 6, names: ["STEM Bridge", "Apprenticeship"] },
+    ],
+  },
+  "business-development": {
+    id: "business-development",
+    domains: [
+      { id: "permits", name: "Permit Reform", lat: 40, lng: -100, color: 0xf59e0b, connections: [1, 7], connectionWeights: [0.73, 0.27] },
+      { id: "credit", name: "SME Credit", lat: 12, lng: -58, color: 0x38bdf8, connections: [2, 3], connectionWeights: [0.55, 0.45] },
+      { id: "startup", name: "Startup Hubs", lat: 50, lng: 11, color: 0xa855f7, connections: [3, 4], connectionWeights: [0.58, 0.42] },
+      { id: "workforce", name: "Workforce Upskill", lat: 32, lng: 84, color: 0x10b981, connections: [4, 5], connectionWeights: [0.64, 0.36] },
+      { id: "infra-bottle", name: "Infra Bottleneck", lat: -22, lng: -32, color: 0xef4444, connections: [5, 7], connectionWeights: [0.46, 0.54] },
+      { id: "exports", name: "Export Growth", lat: -9, lng: 38, color: 0x22d3ee, connections: [6, 4], connectionWeights: [0.72, 0.28] },
+      { id: "tax-base", name: "Tax Base Lift", lat: -42, lng: 121, color: 0x06b6d4, connections: [6, 1], connectionWeights: [0.77, 0.23] },
+      { id: "stagnation", name: "Stagnation", lat: -28, lng: -116, color: 0x64748b, connections: [7, 2], connectionWeights: [0.79, 0.21] },
+    ],
+    childDefs: [
+      { parentIdx: 1, names: ["Microloans", "Supplier Credit"] },
+      { parentIdx: 2, names: ["Incubators", "R&D Grants"] },
+      { parentIdx: 5, names: ["Port Digitize", "Trade Corridors"] },
+    ],
+  },
+  "carbon-tax-loop": {
+    id: "carbon-tax-loop",
+    domains: [
+      { id: "legislation", name: "Legislation", lat: 42, lng: -96, color: 0xa855f7, connections: [1, 7], connectionWeights: [0.62, 0.38] },
+      { id: "enforcement", name: "Enforcement", lat: 16, lng: -61, color: 0xec4899, connections: [2, 3], connectionWeights: [0.7, 0.3] },
+      { id: "industry", name: "Industry Shift", lat: 53, lng: 12, color: 0x10b981, connections: [3, 4], connectionWeights: [0.76, 0.24] },
+      { id: "green-capex", name: "Green Capex", lat: 31, lng: 80, color: 0x0ea5e9, connections: [4, 5], connectionWeights: [0.58, 0.42] },
+      { id: "growth", name: "Green Growth", lat: -19, lng: -30, color: 0x22c55e, connections: [5, 6], connectionWeights: [0.67, 0.33] },
+      { id: "jobs-shift", name: "Job Transition", lat: -10, lng: 42, color: 0x84cc16, connections: [6, 7], connectionWeights: [0.56, 0.44] },
+      { id: "stability", name: "Market Stability", lat: -39, lng: 122, color: 0x14b8a6, connections: [6, 4], connectionWeights: [0.74, 0.26] },
+      { id: "lobby", name: "Lobby Backlash", lat: -29, lng: -120, color: 0x64748b, connections: [7, 1], connectionWeights: [0.81, 0.19] },
+    ],
+    childDefs: [
+      { parentIdx: 2, names: ["Wind R&D", "Solar Subsidy", "Hydrogen"] },
+      { parentIdx: 5, names: ["Reskilling", "Wage Bridge"] },
+      { parentIdx: 7, names: ["Delay Rules", "Court Appeals"] },
+    ],
+  },
+  "urban-transit": {
+    id: "urban-transit",
+    domains: [
+      { id: "urban-design", name: "Urban Design", lat: 41, lng: -98, color: 0xf43f5e, connections: [1, 2], connectionWeights: [0.5, 0.5] },
+      { id: "subway", name: "Subway Expansion", lat: 14, lng: -57, color: 0x0ea5e9, connections: [3, 7], connectionWeights: [0.8, 0.2] },
+      { id: "pricing", name: "Congestion Pricing", lat: 52, lng: 9, color: 0xf97316, connections: [3, 7], connectionWeights: [0.55, 0.45] },
+      { id: "mode-shift", name: "Mode Shift", lat: 29, lng: 81, color: 0x10b981, connections: [4, 7], connectionWeights: [0.72, 0.28] },
+      { id: "ridership", name: "Ridership Gain", lat: -20, lng: -29, color: 0x22c55e, connections: [5, 7], connectionWeights: [0.82, 0.18] },
+      { id: "air-quality", name: "Air Quality", lat: -11, lng: 39, color: 0x22d3ee, connections: [6, 7], connectionWeights: [0.74, 0.26] },
+      { id: "economic-up", name: "Systemic Success", lat: -40, lng: 119, color: 0x06b6d4, connections: [] },
+      { id: "backlash", name: "Backlash Spiral", lat: -31, lng: -122, color: 0x64748b, connections: [] },
+    ],
+    childDefs: [
+      { parentIdx: 1, names: ["Rolling Stock", "Signal Upgrade"] },
+      { parentIdx: 2, names: ["Core Tolling", "Outer Ring Fee"] },
+      { parentIdx: 4, names: ["Last-Mile", "Night Service"] },
+    ],
+  },
+};
+
+const POLICY_PRESETS: PolicyPreset[] = [
+  {
+    id: "ev-charging",
+    label: "EV Charging",
+    scenarioId: "ev-charging",
+    years: 15,
+    iterations: 1800,
+    discountRate: 0.038,
+    volatility: 0.62,
+    funding: [78, 45, 52, 44, 72, 48, 76, 80],
+  },
+  {
+    id: "childhood-education",
+    label: "Childhood Education",
+    scenarioId: "childhood-education",
+    years: 22,
+    iterations: 2100,
+    discountRate: 0.03,
+    volatility: 0.5,
+    funding: [52, 50, 70, 88, 56, 62, 64, 50],
+  },
+  {
+    id: "business-development",
+    label: "Business Development",
+    scenarioId: "business-development",
+    years: 14,
+    iterations: 1900,
+    discountRate: 0.04,
+    volatility: 0.68,
+    funding: [68, 52, 58, 56, 84, 62, 60, 72],
+  },
+  {
+    id: "carbon-tax-loop",
+    label: "Carbon Tax Loop",
+    scenarioId: "carbon-tax-loop",
+    years: 18,
+    iterations: 2000,
+    discountRate: 0.034,
+    volatility: 0.72,
+    funding: [58, 55, 54, 49, 66, 59, 86, 57],
+  },
+  {
+    id: "urban-transit",
+    label: "Urban Transit 30Y",
+    scenarioId: "urban-transit",
+    years: 30,
+    iterations: 1500,
+    discountRate: 0.04,
+    volatility: 0.62,
+    funding: [62, 55, 58, 61, 72, 68, 88, 38],
+  },
 ];
 
 function latLngToVec3(lat: number, lng: number, radius: number): THREE.Vector3 {
@@ -25,6 +173,33 @@ function latLngToVec3(lat: number, lng: number, radius: number): THREE.Vector3 {
     radius * Math.cos(phi),
     radius * Math.sin(phi) * Math.sin(theta),
   );
+}
+
+function createTextSprite(text: string, scaleX = 1.8, scaleY = 0.45): THREE.Sprite {
+  const canvas = document.createElement("canvas");
+  canvas.width = 384;
+  canvas.height = 96;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#f8fbff";
+    ctx.font = "700 31px Arial";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.shadowColor = "rgba(0, 0, 0, 0.65)";
+    ctx.shadowBlur = 8;
+    ctx.fillText(text, canvas.width / 2, canvas.height / 2 + 1);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  const material = new THREE.SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+  });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(scaleX, scaleY, 1);
+  return sprite;
 }
 
 const nodeGlowVert = `
@@ -83,9 +258,10 @@ void main() {
 interface PolicyNode {
   mesh: THREE.Mesh;
   material: THREE.ShaderMaterial;
+  label: THREE.Sprite;
   position: THREE.Vector3;
   funding: number;
-  domain: typeof POLICY_DOMAINS[number];
+  domain: PolicyDomain;
 }
 
 interface PolicyConnection {
@@ -97,11 +273,26 @@ interface PolicyConnection {
   particleMaterial: THREE.PointsMaterial;
   particlePositions: Float32Array;
   curvePoints: THREE.Vector3[];
+  phaseOffset: number;
+  flowSpeed: number;
+  flowDirection: 1 | -1;
+}
+
+interface ChildNode {
+  mesh: THREE.Mesh;
+  label: THREE.Sprite;
+  position: THREE.Vector3;
+  parentIdx: number;
+}
+
+interface ChildLink {
+  line: THREE.Line;
+  material: THREE.LineBasicMaterial;
 }
 
 class PolicySimVisualization {
   scene = new THREE.Scene();
-  camera = new THREE.PerspectiveCamera(45, 1, 0.1, 200);
+  camera = new THREE.PerspectiveCamera(45, 1, 0.1, 220);
   renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
   container: HTMLElement;
   frameId = 0;
@@ -116,12 +307,50 @@ class PolicySimVisualization {
   private globe!: THREE.Mesh;
   private globeWireframe!: THREE.LineSegments;
   private nodes: PolicyNode[] = [];
+  private childNodes: ChildNode[] = [];
   private connections: PolicyConnection[] = [];
+  private childLinks: ChildLink[] = [];
+  private networkGroup = new THREE.Group();
+  private domains: PolicyDomain[] = [];
+  private childDefs: ChildNodeDef[] = [];
+
+  private markovModel!: MarkovChainModel;
+  private shadowCostModel!: ShadowCostModel;
+  private monteCarloModel!: MonteCarloModel;
+  private histogram = new PolicyHistogram(28, 1.55);
+  private histogramValues = Array.from({ length: 28 }, () => 0);
+  private histogramMeta: HistogramMeta = {
+    xMin: -1,
+    xMax: 1,
+    yMin: 0,
+    yMax: 1,
+    mean: 0,
+    meanA: 0,
+    meanB: 0,
+    bimodal: false,
+    breakEvenX: 0,
+    p10: -0.5,
+    p90: 0.5,
+  };
+
+  private activePreset = POLICY_PRESETS[0];
+  private simParams: MonteCarloParams = {
+    years: this.activePreset.years,
+    iterations: this.activePreset.iterations,
+    discountRate: this.activePreset.discountRate,
+    volatility: this.activePreset.volatility,
+  };
+  private modelDirty = true;
+  private lastModelSolve = 0;
+  private lastBatchSolve = 0;
+  private monteCarloVisible = true;
+  private summaryText = "running model";
+  private accumulatedNpvs: number[] = [];
+  private totalSimulations = 0;
+  private batchStartNode = 0;
+  private activeScenarioId = "";
 
   orbitSpeed = 0.08;
-  private orbitAngle = 0;
-  private cameraRadius = 10;
-  private cameraHeight = 3;
   private globeRadius = 3;
   private nodeRadius = 3.4;
 
@@ -137,25 +366,21 @@ class PolicySimVisualization {
     canvas.style.left = "0";
     canvas.style.width = "100%";
     canvas.style.height = "100%";
+    this.container.appendChild(canvas);
 
-    const existingCanvas = container.querySelector("canvas");
-    if (existingCanvas) {
-      this.renderer.domElement = existingCanvas as HTMLCanvasElement;
-    } else {
-      this.container.appendChild(canvas);
-    }
-
-    this.camera.position.set(0, this.cameraHeight, this.cameraRadius);
+    this.camera.position.set(0, 2.5, 10);
     this.camera.lookAt(0, 0, 0);
 
-    this.scene.add(new THREE.AmbientLight(0xffffff, 0.3));
-    const keyLight = new THREE.DirectionalLight(0xffffff, 0.6);
-    keyLight.position.set(5, 5, 5);
+    this.scene.add(this.camera);
+    this.scene.add(this.networkGroup);
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.34));
+    const keyLight = new THREE.DirectionalLight(0xffffff, 0.7);
+    keyLight.position.set(5, 6, 5);
     this.scene.add(keyLight);
 
     this.initGlobe();
-    this.initNodes();
-    this.initConnections();
+    this.initHistogram();
+    this.applyPreset(this.activePreset);
 
     this.resize();
     this.animate();
@@ -181,7 +406,7 @@ class PolicySimVisualization {
       side: THREE.FrontSide,
     });
     this.globe = new THREE.Mesh(globeGeo, globeMat);
-    this.scene.add(this.globe);
+    this.networkGroup.add(this.globe);
 
     const wireGeo = new THREE.IcosahedronGeometry(this.globeRadius * 1.002, 2);
     const wireMat = new THREE.LineBasicMaterial({
@@ -189,18 +414,14 @@ class PolicySimVisualization {
       transparent: true,
       opacity: 0.15,
     });
-    this.globeWireframe = new THREE.LineSegments(
-      new THREE.WireframeGeometry(wireGeo),
-      wireMat,
-    );
-    this.scene.add(this.globeWireframe);
+    this.globeWireframe = new THREE.LineSegments(new THREE.WireframeGeometry(wireGeo), wireMat);
+    this.networkGroup.add(this.globeWireframe);
   }
 
   private initNodes() {
-    const nodeGeo = new THREE.SphereGeometry(0.18, 16, 16);
-
-    for (const domain of POLICY_DOMAINS) {
+    for (const domain of this.domains) {
       const pos = latLngToVec3(domain.lat, domain.lng, this.nodeRadius);
+      const nodeGeo = new THREE.SphereGeometry(0.18, 16, 16);
       const mat = new THREE.ShaderMaterial({
         uniforms: {
           uColor: { value: new THREE.Color(domain.color) },
@@ -214,17 +435,62 @@ class PolicySimVisualization {
 
       const mesh = new THREE.Mesh(nodeGeo, mat);
       mesh.position.copy(pos);
-      this.scene.add(mesh);
+      this.networkGroup.add(mesh);
 
-      this.nodes.push({ mesh, material: mat, position: pos, funding: 50, domain });
+      const label = createTextSprite(domain.name, 2.05, 0.5);
+      label.position.set(pos.x, pos.y + 0.48, pos.z);
+      this.networkGroup.add(label);
+
+      this.nodes.push({ mesh, material: mat, label, position: pos, funding: 50, domain });
+    }
+  }
+
+  private initChildNodes() {
+    for (const childDef of this.childDefs) {
+      const parent = this.nodes[childDef.parentIdx];
+      if (!parent) continue;
+
+      for (let i = 0; i < childDef.names.length; i++) {
+        const theta = (i / childDef.names.length) * Math.PI * 2 + childDef.parentIdx * 0.23;
+        const radial = 0.55 + i * 0.06;
+        const pos = parent.position
+          .clone()
+          .add(new THREE.Vector3(Math.cos(theta) * radial, 0.28 + i * 0.03, Math.sin(theta) * radial));
+
+        const mat = new THREE.MeshStandardMaterial({
+          color: 0x95b9d8,
+          emissive: 0x2e4355,
+          emissiveIntensity: 0.8,
+          roughness: 0.35,
+          metalness: 0.25,
+          transparent: true,
+          opacity: 0.95,
+        });
+        const nodeGeo = new THREE.SphereGeometry(0.11, 14, 14);
+        const mesh = new THREE.Mesh(nodeGeo, mat);
+        mesh.position.copy(pos);
+        this.networkGroup.add(mesh);
+
+        const label = createTextSprite(childDef.names[i], 1.55, 0.4);
+        label.position.set(pos.x, pos.y + 0.26, pos.z);
+        this.networkGroup.add(label);
+
+        const lineGeo = new THREE.BufferGeometry().setFromPoints([parent.position, pos]);
+        const lineMat = new THREE.LineBasicMaterial({ color: 0x7ea7c8, transparent: true, opacity: 0.45 });
+        const line = new THREE.Line(lineGeo, lineMat);
+        this.networkGroup.add(line);
+
+        this.childNodes.push({ mesh, label, position: pos, parentIdx: childDef.parentIdx });
+        this.childLinks.push({ line, material: lineMat });
+      }
     }
   }
 
   private initConnections() {
     const built = new Set<string>();
 
-    for (let i = 0; i < POLICY_DOMAINS.length; i++) {
-      for (const j of POLICY_DOMAINS[i].connections) {
+    for (let i = 0; i < this.domains.length; i++) {
+      for (const j of this.domains[i].connections) {
         const key = i < j ? `${i}-${j}` : `${j}-${i}`;
         if (built.has(key)) continue;
         built.add(key);
@@ -238,16 +504,12 @@ class PolicySimVisualization {
         const curve = new THREE.QuadraticBezierCurve3(from, mid, to);
         const curvePoints = curve.getPoints(32);
         const lineGeo = new THREE.BufferGeometry().setFromPoints(curvePoints);
-        const lineMat = new THREE.LineBasicMaterial({
-          color: 0x44aa66,
-          transparent: true,
-          opacity: 0.4,
-        });
+        const lineMat = new THREE.LineBasicMaterial({ color: 0x44aa66, transparent: true, opacity: 0.35 });
         const line = new THREE.Line(lineGeo, lineMat);
-        this.scene.add(line);
+        this.networkGroup.add(line);
 
-        const numParticles = 6;
-        const particlePositions = new Float32Array(numParticles * 3);
+        const particleCount = 6;
+        const particlePositions = new Float32Array(particleCount * 3);
         const particleGeo = new THREE.BufferGeometry();
         particleGeo.setAttribute("position", new THREE.BufferAttribute(particlePositions, 3));
         const particleMat = new THREE.PointsMaterial({
@@ -258,20 +520,320 @@ class PolicySimVisualization {
           sizeAttenuation: true,
         });
         const particles = new THREE.Points(particleGeo, particleMat);
-        this.scene.add(particles);
+        this.networkGroup.add(particles);
 
         this.connections.push({
-          line, material: lineMat, fromIdx: i, toIdx: j,
-          particles, particleMaterial: particleMat, particlePositions, curvePoints,
+          line,
+          material: lineMat,
+          fromIdx: i,
+          toIdx: j,
+          particles,
+          particleMaterial: particleMat,
+          particlePositions,
+          curvePoints,
+          phaseOffset: Math.random(),
+          flowSpeed: 0.3,
+          flowDirection: 1,
         });
       }
     }
   }
 
-  setFunding(index: number, value: number) {
-    if (index >= 0 && index < this.nodes.length) {
-      this.nodes[index].funding = value;
+  private initHistogram() {
+    this.histogram.group.position.set(0, -2.35, -7.5);
+    this.histogram.group.rotation.set(0, 0, 0);
+    this.camera.add(this.histogram.group);
+  }
+
+  private clearScenario(): void {
+    for (const conn of this.connections) {
+      this.networkGroup.remove(conn.line, conn.particles);
+      conn.line.geometry.dispose();
+      conn.material.dispose();
+      conn.particles.geometry.dispose();
+      conn.particleMaterial.dispose();
     }
+    this.connections = [];
+
+    for (const node of this.nodes) {
+      this.networkGroup.remove(node.mesh, node.label);
+      node.mesh.geometry.dispose();
+      node.material.dispose();
+      const mat = node.label.material as THREE.SpriteMaterial;
+      mat.map?.dispose();
+      mat.dispose();
+    }
+    this.nodes = [];
+
+    for (const child of this.childNodes) {
+      this.networkGroup.remove(child.mesh, child.label);
+      child.mesh.geometry.dispose();
+      (child.mesh.material as THREE.Material).dispose();
+      const mat = child.label.material as THREE.SpriteMaterial;
+      mat.map?.dispose();
+      mat.dispose();
+    }
+    this.childNodes = [];
+
+    for (const link of this.childLinks) {
+      this.networkGroup.remove(link.line);
+      link.line.geometry.dispose();
+      link.material.dispose();
+    }
+    this.childLinks = [];
+  }
+
+  private setupScenario(scenarioId: string): void {
+    const scenario = POLICY_SCENARIOS[scenarioId] ?? POLICY_SCENARIOS[POLICY_PRESETS[0].scenarioId];
+    const scenarioChanged = scenario.id !== this.activeScenarioId;
+    if (scenarioChanged) {
+      this.clearScenario();
+      this.activeScenarioId = scenario.id;
+      this.domains = scenario.domains.map((d) => ({ ...d, connections: [...d.connections], connectionWeights: d.connectionWeights ? [...d.connectionWeights] : undefined }));
+      this.childDefs = scenario.childDefs.map((c) => ({ parentIdx: c.parentIdx, names: [...c.names] }));
+      this.initNodes();
+      this.initChildNodes();
+      this.initConnections();
+    }
+    this.markovModel = new MarkovChainModel(this.domains);
+    this.shadowCostModel = new ShadowCostModel(this.domains);
+    this.monteCarloModel = new MonteCarloModel(this.markovModel, this.shadowCostModel);
+  }
+
+  applyPreset(preset: PolicyPreset): void {
+    this.activePreset = preset;
+    this.setupScenario(preset.scenarioId);
+    this.simParams = {
+      years: preset.years,
+      iterations: preset.iterations,
+      discountRate: preset.discountRate,
+      volatility: preset.volatility,
+    };
+
+    for (let i = 0; i < this.nodes.length; i++) {
+      this.nodes[i].funding = preset.funding[i] ?? 50;
+    }
+
+    this.modelDirty = true;
+    this.resetSimulationAccumulator();
+    this.solveModel(true);
+  }
+
+  setVolatility(value: number): void {
+    this.simParams.volatility = value;
+    this.modelDirty = true;
+    this.resetSimulationAccumulator();
+    this.solveModel(true);
+  }
+
+  setMonteCarloVisible(visible: boolean): void {
+    this.monteCarloVisible = visible;
+    this.histogram.setVisible(visible);
+  }
+
+  getMonteCarloVisible(): boolean {
+    return this.monteCarloVisible;
+  }
+
+  getVolatility(): number {
+    return this.simParams.volatility;
+  }
+
+  getActivePreset(): PolicyPreset {
+    return this.activePreset;
+  }
+
+  getSummaryText(): string {
+    return this.summaryText;
+  }
+
+  private solveModel(force = false): void {
+    if (!force && !this.modelDirty && this.time - this.lastModelSolve < 1.5) return;
+
+    const nodeScores = this.nodes.map((node, idx) =>
+      this.shadowCostModel.estimateExpectedNodeValue(idx, node.funding, this.simParams),
+    );
+
+    this.markovModel.updateWeights(nodeScores, this.simParams.volatility);
+
+    for (const conn of this.connections) {
+      const forward = this.markovModel.getWeight(conn.fromIdx, conn.toIdx);
+      const reverse = this.markovModel.getWeight(conn.toIdx, conn.fromIdx);
+      const dominant = Math.max(forward, reverse);
+      const net = forward - reverse;
+
+      conn.flowDirection = net >= 0 ? 1 : -1;
+      conn.flowSpeed = 0.015 + dominant * 0.08;
+
+      const hue = 0.03 + dominant * 0.33;
+      const color = new THREE.Color().setHSL(hue, 0.78, 0.56);
+      conn.material.color.copy(color);
+      conn.material.opacity = 0.18 + dominant * 0.72;
+      conn.particleMaterial.color.copy(color.clone().offsetHSL(0.05, -0.08, 0.1));
+    }
+
+    this.runSimulationBatch(true);
+
+    this.lastModelSolve = this.time;
+    this.modelDirty = false;
+  }
+
+  private resetSimulationAccumulator(): void {
+    this.accumulatedNpvs = [];
+    this.totalSimulations = 0;
+    this.batchStartNode = 0;
+    this.lastBatchSolve = 0;
+    this.histogramValues = this.histogramValues.map(() => 0);
+    this.histogramMeta = {
+      xMin: -1,
+      xMax: 1,
+      yMin: 0,
+      yMax: 1,
+      mean: 0,
+      meanA: 0,
+      meanB: 0,
+      bimodal: false,
+      breakEvenX: 0,
+      p10: -0.5,
+      p90: 0.5,
+    };
+    this.summaryText = `${this.simParams.years}Y | E[NPV] 0.00M | P+ 0.0% | Sims 0`;
+  }
+
+  private runSimulationBatch(force = false): void {
+    if (!force && this.time - this.lastBatchSolve < 0.18) return;
+    if (this.nodes.length === 0) return;
+
+    const iterations = Math.max(24, Math.min(120, Math.floor(this.simParams.iterations / 20)));
+    const startNode = this.batchStartNode % this.nodes.length;
+    this.batchStartNode = (this.batchStartNode + 1) % this.nodes.length;
+
+    const batch = this.monteCarloModel.run(
+      startNode,
+      this.nodes.map((n) => n.funding),
+      { ...this.simParams, iterations },
+    );
+
+    for (const result of batch.results) {
+      this.accumulatedNpvs.push(result.totalNpv);
+    }
+    this.totalSimulations += batch.results.length;
+
+    const maxStored = 25000;
+    if (this.accumulatedNpvs.length > maxStored) {
+      const removeCount = this.accumulatedNpvs.length - maxStored;
+      this.accumulatedNpvs.splice(0, removeCount);
+    }
+
+    this.rebuildHistogramFromAccumulated();
+    this.lastBatchSolve = this.time;
+  }
+
+  private rebuildHistogramFromAccumulated(): void {
+    if (this.accumulatedNpvs.length === 0) return;
+
+    const min = Math.min(...this.accumulatedNpvs);
+    const max = Math.max(...this.accumulatedNpvs);
+    const span = Math.max(1, max - min);
+    const bins = Array.from({ length: this.histogramValues.length }, () => 0);
+    for (const value of this.accumulatedNpvs) {
+      const idx = Math.min(bins.length - 1, Math.floor(((value - min) / span) * bins.length));
+      bins[idx]++;
+    }
+    const peak = Math.max(...bins, 1);
+    this.histogramValues = bins.map((v) => v / peak);
+
+    const sum = this.accumulatedNpvs.reduce((acc, v) => acc + v, 0);
+    const mean = sum / this.accumulatedNpvs.length;
+    const sorted = [...this.accumulatedNpvs].sort((a, b) => a - b);
+    const q = (p: number) => {
+      const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor((sorted.length - 1) * p)));
+      return sorted[idx];
+    };
+    const successInWindow = this.accumulatedNpvs.reduce((acc, v) => acc + (v >= 0 ? 1 : 0), 0);
+    const successProbability = successInWindow / Math.max(1, this.accumulatedNpvs.length);
+    const modeStats = this.detectModeMeans(bins, min, span, mean);
+
+    this.histogramMeta = {
+      xMin: min,
+      xMax: max,
+      yMin: 0,
+      yMax: peak,
+      mean,
+      meanA: modeStats.meanA,
+      meanB: modeStats.meanB,
+      bimodal: modeStats.bimodal,
+      breakEvenX: 0,
+      p10: q(0.1),
+      p90: q(0.9),
+    };
+
+    const npvM = mean / 1e6;
+    const probPct = successProbability * 100;
+    this.summaryText = `${this.simParams.years}Y | E[NPV] ${npvM.toFixed(2)}M | P+ ${probPct.toFixed(1)}% | Sims ${this.totalSimulations.toLocaleString()}`;
+  }
+
+  private detectModeMeans(
+    bins: number[],
+    min: number,
+    span: number,
+    fallbackMean: number,
+  ): { bimodal: boolean; meanA: number; meanB: number } {
+    const localPeaks: Array<{ idx: number; count: number }> = [];
+    for (let i = 0; i < bins.length; i++) {
+      const prev = i > 0 ? bins[i - 1] : -1;
+      const next = i < bins.length - 1 ? bins[i + 1] : -1;
+      if (bins[i] >= prev && bins[i] >= next && bins[i] > 0) {
+        localPeaks.push({ idx: i, count: bins[i] });
+      }
+    }
+    if (localPeaks.length < 2) {
+      return { bimodal: false, meanA: fallbackMean, meanB: fallbackMean };
+    }
+
+    localPeaks.sort((a, b) => b.count - a.count);
+    const primary = localPeaks[0];
+    const minGap = Math.max(3, Math.floor(bins.length * 0.2));
+    const secondary = localPeaks.find(
+      (p) => Math.abs(p.idx - primary.idx) >= minGap && p.count >= primary.count * 0.35,
+    );
+    if (!secondary) {
+      return { bimodal: false, meanA: fallbackMean, meanB: fallbackMean };
+    }
+
+    const leftPeak = primary.idx < secondary.idx ? primary : secondary;
+    const rightPeak = primary.idx < secondary.idx ? secondary : primary;
+    let valleyIdx = leftPeak.idx;
+    let valleyCount = bins[leftPeak.idx];
+    for (let i = leftPeak.idx + 1; i < rightPeak.idx; i++) {
+      if (bins[i] < valleyCount) {
+        valleyCount = bins[i];
+        valleyIdx = i;
+      }
+    }
+
+    const splitValue = min + ((valleyIdx + 0.5) / bins.length) * span;
+    let leftSum = 0;
+    let leftN = 0;
+    let rightSum = 0;
+    let rightN = 0;
+    for (const v of this.accumulatedNpvs) {
+      if (v <= splitValue) {
+        leftSum += v;
+        leftN++;
+      } else {
+        rightSum += v;
+        rightN++;
+      }
+    }
+    if (leftN < 20 || rightN < 20) {
+      return { bimodal: false, meanA: fallbackMean, meanB: fallbackMean };
+    }
+    return {
+      bimodal: true,
+      meanA: leftSum / leftN,
+      meanB: rightSum / rightN,
+    };
   }
 
   resize = () => {
@@ -287,6 +849,13 @@ class PolicySimVisualization {
     cancelAnimationFrame(this.frameId);
     this.resizeObserver?.disconnect();
     window.removeEventListener("resize", this.resize);
+    this.clearScenario();
+    this.networkGroup.remove(this.globe, this.globeWireframe);
+    this.globe.geometry.dispose();
+    (this.globe.material as THREE.Material).dispose();
+    this.globeWireframe.geometry.dispose();
+    (this.globeWireframe.material as THREE.Material).dispose();
+    this.histogram.dispose();
     this.renderer.dispose();
     if (this.container.contains(this.renderer.domElement)) {
       this.container.removeChild(this.renderer.domElement);
@@ -304,45 +873,43 @@ class PolicySimVisualization {
 
     this.time += 0.016;
     this.frameCount++;
-
-    this.orbitAngle += this.orbitSpeed * 0.016;
-    const camX = Math.cos(this.orbitAngle) * this.cameraRadius;
-    const camZ = Math.sin(this.orbitAngle) * this.cameraRadius;
-    this.camera.position.set(camX, this.cameraHeight, camZ);
-    this.camera.lookAt(0, 0, 0);
+    this.networkGroup.rotation.y += this.orbitSpeed * 0.016;
 
     this.globe.rotation.y = this.time * 0.02;
     this.globeWireframe.rotation.y = this.time * 0.02;
 
     for (const node of this.nodes) {
-      const scale = 0.5 + (node.funding / 100) * 1.5;
+      const scale = 0.55 + (node.funding / 100) * 1.2;
       node.mesh.scale.setScalar(scale);
       node.material.uniforms.uPulse.value = node.funding / 100;
       node.material.uniforms.uTime.value = this.time;
     }
 
+    this.solveModel(false);
+    this.runSimulationBatch(false);
+
     for (const conn of this.connections) {
-      const fromFunding = this.nodes[conn.fromIdx].funding;
-      const toFunding = this.nodes[conn.toIdx].funding;
-      const balance = (fromFunding + toFunding) / 200;
-
-      conn.material.color.setRGB(1.0 - balance, balance, balance * 0.3);
-      conn.material.opacity = 0.2 + balance * 0.5;
-      conn.particleMaterial.color.setRGB(0.3 + balance * 0.5, 0.5 + balance * 0.5, 0.3 + balance * 0.15);
-
-      const numP = conn.particlePositions.length / 3;
+      const particleCount = conn.particlePositions.length / 3;
       const curveLen = conn.curvePoints.length;
-      for (let p = 0; p < numP; p++) {
-        const t = ((this.time * 0.3 + p / numP) % 1.0);
-        const idx = Math.floor(t * (curveLen - 1));
-        const frac = t * (curveLen - 1) - idx;
+
+      for (let p = 0; p < particleCount; p++) {
+        const local = (this.time * conn.flowSpeed + conn.phaseOffset + p / particleCount) % 1;
+        const t = conn.flowDirection === 1 ? local : 1 - local;
+        const f = t * (curveLen - 1);
+        const idx = Math.floor(f);
+        const frac = f - idx;
         const a = conn.curvePoints[idx];
-        const bPt = conn.curvePoints[Math.min(idx + 1, curveLen - 1)];
-        conn.particlePositions[p * 3] = a.x + (bPt.x - a.x) * frac;
-        conn.particlePositions[p * 3 + 1] = a.y + (bPt.y - a.y) * frac;
-        conn.particlePositions[p * 3 + 2] = a.z + (bPt.z - a.z) * frac;
+        const b = conn.curvePoints[Math.min(idx + 1, curveLen - 1)];
+        conn.particlePositions[p * 3] = a.x + (b.x - a.x) * frac;
+        conn.particlePositions[p * 3 + 1] = a.y + (b.y - a.y) * frac;
+        conn.particlePositions[p * 3 + 2] = a.z + (b.z - a.z) * frac;
       }
+
       conn.particles.geometry.attributes.position.needsUpdate = true;
+    }
+
+    if (this.monteCarloVisible) {
+      this.histogram.update(this.histogramValues, this.histogramMeta, this.totalSimulations);
     }
 
     const cpuStart = performance.now();
@@ -363,23 +930,53 @@ export function mountPolicy(container: HTMLElement) {
     </div>
   `;
 
-  const subtitleEl = container.querySelector(
-    "[data-typing-subtitle]",
-  ) as HTMLParagraphElement | null;
+  const subtitleEl = container.querySelector("[data-typing-subtitle]") as HTMLParagraphElement | null;
   const subtitles = [
-    "Adjust funding. Watch cascading effects.",
-    "Eight domains. One interconnected system.",
-    "Balance resources across a simulated world.",
-    "Every policy decision has consequences.",
+    "Markov transitions and shadow costs, solved in real time.",
+    "Monte Carlo outcomes update with every preset and volatility shift.",
+    "Watch policy flow speed adapt as edge weights rebalance.",
+    "Use presets to compare short, medium, and long-range horizons.",
   ];
   const stopTyping = startTyping(subtitleEl, subtitles);
 
   const viz = new PolicySimVisualization(container);
-  const menuOptions = {
-    domains: POLICY_DOMAINS.map((d) => d.name),
-    orbitSpeed: viz.orbitSpeed,
-    onFundingChange: (index: number, value: number) => viz.setFunding(index, value),
-    onOrbitSpeedChange: (value: number) => { viz.orbitSpeed = value; },
+
+  if (import.meta.env.DEV) {
+    const defaultScenarioDomains = POLICY_SCENARIOS[POLICY_PRESETS[0].scenarioId].domains;
+    const modelIssues = runPolicyModelTests(defaultScenarioDomains);
+    if (modelIssues.length > 0) {
+      console.error("[policy] model checks failed", modelIssues);
+    } else {
+      console.info("[policy] model checks passed");
+    }
+  }
+
+  const refreshMenu = () => {
+    setupPolicyMenu({
+      presets: POLICY_PRESETS,
+      activePresetId: viz.getActivePreset().id,
+      orbitSpeed: viz.orbitSpeed,
+      volatility: viz.getVolatility(),
+      monteCarloVisible: viz.getMonteCarloVisible(),
+      summaryText: viz.getSummaryText(),
+      onPresetChange: (presetId: string) => {
+        const preset = POLICY_PRESETS.find((p) => p.id === presetId);
+        if (!preset) return;
+        viz.applyPreset(preset);
+        refreshMenu();
+      },
+      onOrbitSpeedChange: (value: number) => {
+        viz.orbitSpeed = value;
+      },
+      onVolatilityChange: (value: number) => {
+        viz.setVolatility(value);
+        refreshMenu();
+      },
+      onToggleMonteCarlo: () => {
+        viz.setMonteCarloVisible(!viz.getMonteCarloVisible());
+        refreshMenu();
+      },
+    });
   };
 
   return {
@@ -392,7 +989,7 @@ export function mountPolicy(container: HTMLElement) {
       viz.setVisible(visible);
     },
     updateUI: () => {
-      setupPolicyMenu(menuOptions);
-    }
+      refreshMenu();
+    },
   };
 }

--- a/src/plugins/www/app/src/components/policy/markov_chain_model.ts
+++ b/src/plugins/www/app/src/components/policy/markov_chain_model.ts
@@ -1,0 +1,80 @@
+import type { PolicyDomain } from "./types";
+
+function softmax(values: number[]): number[] {
+  const maxVal = values.reduce((m, v) => (v > m ? v : m), -Infinity);
+  const expVals = values.map((v) => Math.exp(v - maxVal));
+  const total = expVals.reduce((sum, v) => sum + v, 0);
+  if (total <= 0) return values.map(() => 0);
+  return expVals.map((v) => v / total);
+}
+
+export class MarkovChainModel {
+  private transition: number[][];
+  private baseTransition: number[][];
+
+  constructor(domains: PolicyDomain[]) {
+    const count = domains.length;
+    this.baseTransition = Array.from({ length: count }, () => Array.from({ length: count }, () => 0));
+
+    for (let source = 0; source < domains.length; source++) {
+      const domain = domains[source];
+      const outgoing = domain.connections;
+      if (outgoing.length === 0) {
+        this.baseTransition[source][source] = 1;
+        continue;
+      }
+
+      const selfWeight = 0.28;
+      this.baseTransition[source][source] = selfWeight;
+      const rawWeights = domain.connectionWeights;
+      const hasCustomWeights = rawWeights && rawWeights.length === outgoing.length;
+      const weights = hasCustomWeights ? rawWeights : outgoing.map(() => 1);
+      const sumWeights = weights.reduce((s, w) => s + Math.max(0, w), 0);
+      const normalizer = sumWeights > 0 ? sumWeights : outgoing.length;
+      for (let i = 0; i < outgoing.length; i++) {
+        const target = outgoing[i];
+        const weight = hasCustomWeights ? Math.max(0, weights[i]) : 1;
+        this.baseTransition[source][target] = ((1 - selfWeight) * weight) / normalizer;
+      }
+    }
+
+    this.transition = this.baseTransition.map((row) => [...row]);
+  }
+
+  updateWeights(nodeScores: number[], volatility: number): void {
+    const scoreScale = Math.max(0.05, volatility);
+    for (let source = 0; source < this.transition.length; source++) {
+      const raw: number[] = [];
+      const activeTargets: number[] = [];
+      for (let target = 0; target < this.transition[source].length; target++) {
+        const base = this.baseTransition[source][target];
+        if (base <= 0) continue;
+        activeTargets.push(target);
+        raw.push(Math.log(base + 1e-6) + nodeScores[target] * scoreScale * 1e-7);
+      }
+
+      const norm = softmax(raw);
+      for (let target = 0; target < this.transition[source].length; target++) {
+        this.transition[source][target] = 0;
+      }
+      for (let i = 0; i < activeTargets.length; i++) {
+        this.transition[source][activeTargets[i]] = norm[i];
+      }
+    }
+  }
+
+  getWeight(source: number, target: number): number {
+    return this.transition[source]?.[target] ?? 0;
+  }
+
+  sampleNext(source: number, rng: () => number): number {
+    const row = this.transition[source];
+    if (!row) return source;
+    let r = rng();
+    for (let i = 0; i < row.length; i++) {
+      r -= row[i];
+      if (r <= 0) return i;
+    }
+    return source;
+  }
+}

--- a/src/plugins/www/app/src/components/policy/menu.ts
+++ b/src/plugins/www/app/src/components/policy/menu.ts
@@ -1,38 +1,60 @@
 import { Menu } from "../util/menu";
+import type { PolicyPreset } from "./types";
 
 type PolicyMenuOptions = {
-    domains: string[];
-    orbitSpeed: number;
-    onFundingChange: (index: number, value: number) => void;
-    onOrbitSpeedChange: (value: number) => void;
+  presets: PolicyPreset[];
+  activePresetId: string;
+  orbitSpeed: number;
+  volatility: number;
+  monteCarloVisible: boolean;
+  summaryText: string;
+  onPresetChange: (presetId: string) => void;
+  onOrbitSpeedChange: (value: number) => void;
+  onVolatilityChange: (value: number) => void;
+  onToggleMonteCarlo: () => void;
 };
 
 export function setupPolicyMenu(options: PolicyMenuOptions): void {
-    const menu = Menu.getInstance();
-    menu.clear();
+  const menu = Menu.getInstance();
+  menu.clear();
 
-    menu.addHeader("Camera");
-    menu.addSlider(
-        "Orbit",
-        options.orbitSpeed,
-        0,
-        0.5,
-        0.01,
-        options.onOrbitSpeedChange,
-        (v) => v.toFixed(2),
+  menu.addHeader("Presets");
+  for (const preset of options.presets) {
+    menu.addButton(
+      preset.label,
+      () => options.onPresetChange(preset.id),
+      preset.id === options.activePresetId,
     );
+  }
 
-    menu.addHeader("Policy Funding");
-    for (let i = 0; i < options.domains.length; i++) {
-        const idx = i;
-        menu.addSlider(
-            options.domains[i],
-            50,
-            0,
-            100,
-            1,
-            (v) => options.onFundingChange(idx, v),
-            (v) => Math.round(v).toString(),
-        );
-    }
+  menu.addButton(
+    options.monteCarloVisible ? "Hide Monte Carlo" : "Show Monte Carlo",
+    options.onToggleMonteCarlo,
+    false,
+  );
+
+  menu.addHeader("Model");
+  menu.addSlider(
+    "Orbit",
+    options.orbitSpeed,
+    0,
+    0.55,
+    0.01,
+    options.onOrbitSpeedChange,
+    (v) => v.toFixed(2),
+  );
+
+  menu.addSlider(
+    "Volatility",
+    options.volatility,
+    0.1,
+    2,
+    0.05,
+    options.onVolatilityChange,
+    (v) => v.toFixed(2),
+  );
+
+  menu.addHeader("Run");
+  const status = menu.addStatus();
+  status.update(options.summaryText);
 }

--- a/src/plugins/www/app/src/components/policy/model_tests.ts
+++ b/src/plugins/www/app/src/components/policy/model_tests.ts
@@ -1,0 +1,52 @@
+import { MarkovChainModel } from "./markov_chain_model";
+import { MonteCarloModel } from "./monte_carlo_model";
+import { ShadowCostModel } from "./shadow_cost_model";
+import type { MonteCarloParams, PolicyDomain } from "./types";
+
+export function runPolicyModelTests(domains: PolicyDomain[]): string[] {
+  const issues: string[] = [];
+
+  const markov = new MarkovChainModel(domains);
+  const shadow = new ShadowCostModel(domains);
+  const monteCarlo = new MonteCarloModel(markov, shadow);
+
+  const params: MonteCarloParams = {
+    years: 6,
+    iterations: 80,
+    discountRate: 0.04,
+    volatility: 0.5,
+  };
+
+  const scores = domains.map((_, idx) => shadow.estimateExpectedNodeValue(idx, 55, params));
+  markov.updateWeights(scores, params.volatility);
+
+  for (let source = 0; source < domains.length; source++) {
+    let sum = 0;
+    for (let target = 0; target < domains.length; target++) {
+      const w = markov.getWeight(source, target);
+      if (w < -1e-6 || w > 1 + 1e-6) {
+        issues.push(`invalid markov weight s${source}->t${target}: ${w}`);
+      }
+      sum += w;
+    }
+    if (Math.abs(sum - 1) > 1e-4) {
+      issues.push(`markov row does not normalize for source ${source}: ${sum}`);
+    }
+  }
+
+  const sampleBreakdown = shadow.evaluateNode(0, 50, 0, Math.random);
+  if (Object.keys(sampleBreakdown).length === 0) {
+    issues.push("shadow cost model produced empty breakdown");
+  }
+
+  const funding = domains.map(() => 55);
+  const sim = monteCarlo.run(0, funding, params);
+  if (sim.results.length !== params.iterations) {
+    issues.push(`monte carlo iterations mismatch: ${sim.results.length}`);
+  }
+  if (sim.histogram.length === 0) {
+    issues.push("monte carlo histogram was empty");
+  }
+
+  return issues;
+}

--- a/src/plugins/www/app/src/components/policy/monte_carlo_model.ts
+++ b/src/plugins/www/app/src/components/policy/monte_carlo_model.ts
@@ -1,0 +1,81 @@
+import { MarkovChainModel } from "./markov_chain_model";
+import { ShadowCostModel } from "./shadow_cost_model";
+import type { MonteCarloParams, MonteCarloResult, MonteCarloSummary } from "./types";
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+export class MonteCarloModel {
+  constructor(
+    private markov: MarkovChainModel,
+    private shadowCost: ShadowCostModel,
+  ) {}
+
+  run(startNode: number, funding: number[], params: MonteCarloParams): MonteCarloSummary {
+    const results: MonteCarloResult[] = [];
+    let total = 0;
+    let success = 0;
+
+    for (let iter = 0; iter < params.iterations; iter++) {
+      let current = startNode;
+      let npv = 0;
+      const breakdown: Record<string, number> = {};
+
+      for (let year = 0; year < params.years; year++) {
+        const discountFactor = Math.pow(1 + params.discountRate, -year);
+        const noiseScale = 1 + (Math.random() - 0.5) * params.volatility * 0.3;
+        const impacts = this.shadowCost.evaluateNode(current, funding[current] ?? 50, year, Math.random);
+
+        for (const [key, rawValue] of Object.entries(impacts)) {
+          const value = rawValue * noiseScale;
+          const discounted = value * discountFactor;
+          breakdown[key] = (breakdown[key] ?? 0) + discounted;
+          npv += discounted;
+        }
+
+        current = this.markov.sampleNext(current, Math.random);
+      }
+
+      if (npv >= 0) success++;
+      total += npv;
+      results.push({ totalNpv: npv, finalState: current, breakdown });
+    }
+
+    const expected = results.length > 0 ? total / results.length : 0;
+    const successProbability = results.length > 0 ? success / results.length : 0;
+
+    const values = results.map((r) => r.totalNpv);
+    const min = Math.min(...values, 0);
+    const max = Math.max(...values, 1);
+    const span = Math.max(1, max - min);
+    const binCount = 28;
+    const bins = Array.from({ length: binCount }, () => 0);
+
+    for (const value of values) {
+      const idx = Math.min(binCount - 1, Math.floor(((value - min) / span) * binCount));
+      bins[idx]++;
+    }
+
+    const peak = Math.max(...bins, 1);
+    const histogram = bins.map((v) => clamp01(v / peak));
+
+    return {
+      results,
+      expectedNpv: expected,
+      successProbability,
+      histogram,
+      xMin: min,
+      xMax: max,
+      yMin: 0,
+      yMax: peak,
+      mean: expected,
+      meanA: expected,
+      meanB: expected,
+      bimodal: false,
+      breakEvenX: 0,
+      p10: min + (max - min) * 0.1,
+      p90: min + (max - min) * 0.9,
+    };
+  }
+}

--- a/src/plugins/www/app/src/components/policy/shadow_cost_model.ts
+++ b/src/plugins/www/app/src/components/policy/shadow_cost_model.ts
@@ -1,0 +1,150 @@
+import type { ImpactFlow, MonteCarloParams, PolicyDomain, ShadowPrice } from "./types";
+
+function boxMuller(mean: number, std: number, rng: () => number): number {
+  const u = Math.max(1e-7, 1 - rng());
+  const v = Math.max(1e-7, 1 - rng());
+  const z = Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+  return z * std + mean;
+}
+
+function clampFunding(funding: number): number {
+  return Math.max(0, Math.min(100, funding));
+}
+
+type NodeProfile = {
+  benefitMult: number;
+  costMult: number;
+  riskMult: number;
+  welfareBias: number;
+};
+
+function profileForNode(id: string): NodeProfile {
+  if (id.includes("economic-up") || id.includes("stability")) {
+    return { benefitMult: 3.2, costMult: 0.42, riskMult: 0.2, welfareBias: 1.6 };
+  }
+  if (id.includes("backlash") || id.includes("stall") || id.includes("stagnation") || id.includes("dropout")) {
+    return { benefitMult: 0.35, costMult: 2.9, riskMult: 3.6, welfareBias: -1.45 };
+  }
+  if (id.includes("ridership") || id.includes("air-quality") || id.includes("mode-shift")) {
+    return { benefitMult: 1.55, costMult: 0.78, riskMult: 0.7, welfareBias: 0.5 };
+  }
+  return { benefitMult: 1, costMult: 1, riskMult: 1, welfareBias: 0 };
+}
+
+export class ShadowCostModel {
+  private nodeImpacts: ImpactFlow[][];
+
+  constructor(domains: PolicyDomain[]) {
+    const fiscalSpend: ShadowPrice = {
+      name: "Fiscal Spend",
+      unit: "USD",
+      impactType: "cost",
+      priceFunction: () => 1,
+    };
+
+    const carbonPrice: ShadowPrice = {
+      name: "CO2 Benefit",
+      unit: "T",
+      impactType: "benefit",
+      priceFunction: (rng, year) => boxMuller(120 + year * 2.1, 18, rng),
+    };
+
+    const resiliencePrice: ShadowPrice = {
+      name: "Resilience",
+      unit: "Idx",
+      impactType: "benefit",
+      priceFunction: (rng) => boxMuller(42000, 6000, rng),
+    };
+
+    const welfarePrice: ShadowPrice = {
+      name: "Welfare",
+      unit: "Pts",
+      impactType: "benefit",
+      priceFunction: (rng) => boxMuller(36000, 5200, rng),
+    };
+
+    const riskCost: ShadowPrice = {
+      name: "Risk Cost",
+      unit: "Idx",
+      impactType: "cost",
+      priceFunction: (rng) => boxMuller(50000, 7000, rng),
+    };
+
+    this.nodeImpacts = domains.map((domain, idx) => {
+      const base = 0.6 + (idx % 3) * 0.2;
+      const profile = profileForNode(domain.id);
+      return [
+        {
+          shadowPrice: fiscalSpend,
+          quantityFunction: (funding) => {
+            const f = clampFunding(funding) / 100;
+            return (120000 + f * 320000) * base * profile.costMult;
+          },
+        },
+        {
+          shadowPrice: carbonPrice,
+          quantityFunction: (funding, year) => {
+            const f = clampFunding(funding) / 100;
+            return (f * 750 + year * 14) * (1.05 + base * 0.2) * profile.benefitMult;
+          },
+        },
+        {
+          shadowPrice: resiliencePrice,
+          quantityFunction: (funding, year) => {
+            const f = clampFunding(funding) / 100;
+            return (f * 2.4 + year * 0.08) * (1 + base * 0.1) * profile.benefitMult;
+          },
+        },
+        {
+          shadowPrice: welfarePrice,
+          quantityFunction: (funding) => {
+            const f = clampFunding(funding) / 100;
+            return (Math.max(-2.4, f * 3.1 - 0.9) + profile.welfareBias) * (0.8 + base * 0.15) * profile.benefitMult;
+          },
+        },
+        {
+          shadowPrice: riskCost,
+          quantityFunction: (funding, year) => {
+            const f = clampFunding(funding) / 100;
+            return Math.max(0, (1.2 - f) * (1 + year * 0.03)) * (0.9 + base * 0.1) * profile.riskMult;
+          },
+        },
+      ];
+    });
+  }
+
+  estimateExpectedNodeValue(nodeIndex: number, funding: number, params: MonteCarloParams): number {
+    const impacts = this.nodeImpacts[nodeIndex] ?? [];
+    let total = 0;
+    for (let year = 0; year < params.years; year++) {
+      const discount = Math.pow(1 + params.discountRate, -year);
+      for (const impact of impacts) {
+        const qty = impact.quantityFunction(funding, year);
+        const expectedPrice = impact.shadowPrice.priceFunction(() => 0.5, year);
+        let value = qty * expectedPrice;
+        if (impact.shadowPrice.impactType === "cost") {
+          value = -Math.abs(value);
+        }
+        total += value * discount;
+      }
+    }
+    return total;
+  }
+
+  evaluateNode(nodeIndex: number, funding: number, year: number, rng: () => number): Record<string, number> {
+    const impacts = this.nodeImpacts[nodeIndex] ?? [];
+    const breakdown: Record<string, number> = {};
+
+    for (const impact of impacts) {
+      const qty = impact.quantityFunction(funding, year);
+      const price = impact.shadowPrice.priceFunction(rng, year);
+      let value = qty * price;
+      if (impact.shadowPrice.impactType === "cost") {
+        value = -Math.abs(value);
+      }
+      breakdown[impact.shadowPrice.name] = (breakdown[impact.shadowPrice.name] ?? 0) + value;
+    }
+
+    return breakdown;
+  }
+}

--- a/src/plugins/www/app/src/components/policy/types.ts
+++ b/src/plugins/www/app/src/components/policy/types.ts
@@ -1,0 +1,65 @@
+export interface PolicyDomain {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  color: number;
+  connections: number[];
+  connectionWeights?: number[];
+}
+
+export type ImpactType = "benefit" | "cost";
+
+export interface ShadowPrice {
+  name: string;
+  unit: string;
+  impactType: ImpactType;
+  priceFunction: (rng: () => number, year: number) => number;
+}
+
+export interface ImpactFlow {
+  shadowPrice: ShadowPrice;
+  quantityFunction: (funding: number, year: number) => number;
+}
+
+export interface MonteCarloParams {
+  years: number;
+  iterations: number;
+  discountRate: number;
+  volatility: number;
+}
+
+export interface MonteCarloResult {
+  totalNpv: number;
+  finalState: number;
+  breakdown: Record<string, number>;
+}
+
+export interface MonteCarloSummary {
+  results: MonteCarloResult[];
+  expectedNpv: number;
+  successProbability: number;
+  histogram: number[];
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+  mean: number;
+  meanA: number;
+  meanB: number;
+  bimodal: boolean;
+  breakEvenX: number;
+  p10: number;
+  p90: number;
+}
+
+export interface PolicyPreset {
+  id: string;
+  label: string;
+  scenarioId: string;
+  years: number;
+  iterations: number;
+  discountRate: number;
+  volatility: number;
+  funding: number[];
+}


### PR DESCRIPTION
## Summary
- overhaul policy simulator into TS models for Markov, Monte Carlo, and shadow-cost evaluation
- add scenario-driven presets with distinct node names, edges, and base transition weights
- add nested child nodes per scenario and slower adaptive link animation
- redesign histogram as camera-anchored HUD with moving markers, x-axis labels, and in-chart simulation counter
- add bimodal detection and red mean marker lines (single or dual depending on distribution)
- add `www policy demo` command and implement `www install` to use DIALTONE_ENV bun/npm
- publish bump to v1.0.65

## Validation
- `./dialtone.sh www install`
- `./dialtone.sh www lint`
- `./dialtone.sh www build`
- `./dialtone.sh www policy demo`
- `./dialtone.sh www publish`
