### PR TITLE
DAG v3 UI cleanup: mode forms, nav modal, table form overlay

### DIFF
--- a/src/libs/ui_v2/Menu.ts
+++ b/src/libs/ui_v2/Menu.ts
@@ -1,8 +1,6 @@
 export class Menu {
   private root: HTMLElement;
   private toggle: HTMLButtonElement;
-  private panel: HTMLDivElement;
-  private grid: HTMLDivElement;
   private items: HTMLButtonElement[] = [];
   private readonly onDocumentClick: (event: MouseEvent) => void;
   private readonly onEscape: (event: KeyboardEvent) => void;
@@ -14,28 +12,10 @@ export class Menu {
     this.root.setAttribute('data-overlay', 'menu');
 
     const existingPanel = this.root.querySelector('[aria-label="Global Menu Panel"]');
-    let panel: HTMLDivElement;
     if (existingPanel instanceof HTMLDivElement) {
-      panel = existingPanel;
-    } else {
-      panel = document.createElement('div');
-      panel.setAttribute('aria-label', 'Global Menu Panel');
-      panel.setAttribute('role', 'dialog');
-      panel.setAttribute('aria-modal', 'true');
-      panel.hidden = true;
-      this.root.appendChild(panel);
+      existingPanel.hidden = true;
+      existingPanel.remove();
     }
-    panel.classList.add('menu-panel');
-    panel.setAttribute('role', 'dialog');
-    panel.setAttribute('aria-modal', 'true');
-    this.panel = panel;
-    let grid: HTMLDivElement | null = this.panel.querySelector('.menu-grid');
-    if (!(grid instanceof HTMLDivElement)) {
-      grid = document.createElement('div');
-      grid.classList.add('menu-grid');
-      this.panel.appendChild(grid);
-    }
-    this.grid = grid;
 
     const toggle = document.createElement('button');
     toggle.type = 'button';
@@ -54,7 +34,7 @@ export class Menu {
       if (!this.isOpen()) return;
       const target = event.target as Node | null;
       if (!target) return;
-      if (target === this.panel) {
+      if (target === this.root) {
         this.setOpen(false);
         return;
       }
@@ -85,7 +65,7 @@ export class Menu {
       this.setOpen(false);
     });
     this.items.push(btn);
-    this.grid.appendChild(btn);
+    this.root.appendChild(btn);
   }
 
   private setItemsVisible(visible: boolean): void {
@@ -100,8 +80,10 @@ export class Menu {
 
   private setOpen(open: boolean): void {
     this.setItemsVisible(open);
-    this.panel.hidden = !open;
     this.toggle.setAttribute('aria-expanded', String(open));
+    this.root.setAttribute('data-open', open ? 'true' : 'false');
+    this.root.setAttribute('role', open ? 'dialog' : 'navigation');
+    this.root.setAttribute('aria-modal', open ? 'true' : 'false');
     document.body.classList.toggle('menu-open', open);
     document.body.style.overflow = open ? 'hidden' : '';
     document.documentElement.style.overflow = open ? 'hidden' : '';

--- a/src/libs/ui_v2/README.md
+++ b/src/libs/ui_v2/README.md
@@ -11,7 +11,14 @@ Each `ui` can have many `section`.
 Each `section` is composed from underlays + overlays:
 
 - underlays (exactly one per section): `stage` | `table` | `docs` | `xterm` | `video`
-- overlays (shared UI layers): `menu` (global), `thumbs`, `legend`, optional `chatlog`
+- overlays (shared UI layers): `legend`, `chatlog`, `menu` (global), `thumbs`
+
+Section formula: one underlay + overlays = one section.
+
+Section id naming rule:
+
+- Use `<plugin-name>-<subname>-<underlay-type>`.
+- Examples: `dag-meta-table`, `dag-3d-stage`, `dag-log-xterm`.
 
 ## Menu Overlay Behavior
 
@@ -25,12 +32,12 @@ Each `section` is composed from underlays + overlays:
 `SectionConfig` supports section layer selectors:
 
 ```ts
-sections.register('my-section', {
-  containerId: 'my-section',
+sections.register('dag-meta-table', {
+  containerId: 'dag-meta-table',
   load: async () => mountMySection(),
   overlays: {
-    primaryKind: 'stage',
-    primary: '.my-stage',
+    primaryKind: 'table',
+    primary: '.my-table',
     thumb: '.my-thumbs',
     legend: '.my-legend',
     chatlog: '.my-chatlog',

--- a/src/libs/ui_v2/style.css
+++ b/src/libs/ui_v2/style.css
@@ -67,25 +67,33 @@ nav[hidden] {
   display: none !important;
 }
 
-.menu-panel {
-  position: fixed;
+nav[data-open='true'] {
   inset: 0;
   width: 100vw;
   height: 100vh;
+  left: 0;
+  right: 0;
+  top: 0;
+  display: grid;
+  place-items: center;
   background: rgba(0, 0, 0, 0.74);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   padding: 1rem;
-  border: 0;
   display: grid;
-  place-items: center;
-  color: var(--theme-text);
+  grid-template-columns: 1fr;
+  grid-auto-rows: minmax(56px, auto);
+  gap: 12px;
+  align-content: center;
+  justify-items: center;
   pointer-events: auto;
-  z-index: 1190;
 }
 
-.menu-panel[hidden] {
-  display: none !important;
+nav[data-open='true'] .menu-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1200;
 }
 
 .menu-grid {
@@ -144,9 +152,9 @@ nav[hidden] {
   min-width: min(400px, calc(100vw - 2rem));
   min-height: 56px;
   padding: 10px 14px;
-  background: rgba(8, 14, 26, 0.88);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(240, 246, 255, 0.55);
+  border-radius: 3px;
   color: var(--theme-text);
   cursor: pointer;
   text-align: center;
@@ -155,21 +163,19 @@ nav[hidden] {
   transition: all 0.2s;
 }
 
-.menu-button:hover {
-  background: rgba(18, 26, 44, 0.96);
-  transform: translateY(-1px);
+.menu-button:hover,
+.menu-button:focus-visible {
+  border-color: rgba(125, 211, 252, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.8), inset 0 0 16px rgba(43, 120, 255, 0.42);
+  background: rgba(8, 20, 34, 0.72);
+  outline: 0;
 }
 
 .menu-button-primary {
-  background: var(--theme-gradient);
-  border: none;
-  color: var(--theme-btn-text);
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(240, 246, 255, 0.55);
+  color: var(--theme-text);
   font-weight: 600;
-}
-
-.menu-button-primary:hover {
-  filter: brightness(1.2);
-  box-shadow: 0 4px 15px var(--theme-accent);
 }
 
 body.menu-open [data-overlay='thumb'][data-overlay-active='true'] {
@@ -227,28 +233,33 @@ p {
 }
 
 button {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--theme-border);
-  border-radius: 6px;
-  color: #fff;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(240, 246, 255, 0.55);
+  border-radius: 3px;
+  color: var(--theme-text);
   cursor: pointer;
-  text-align: left;
+  text-align: center;
   font-size: 0.85rem;
+  transition:
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 520ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 520ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 520ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.thumb-button-active {
-  animation: thumb-button-highlight 500ms ease-out;
+button:hover,
+button:focus-visible {
+  border-color: rgba(125, 211, 252, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.8), inset 0 0 16px rgba(43, 120, 255, 0.42);
+  background: rgba(8, 20, 34, 0.72);
+  outline: 0;
 }
 
-@keyframes thumb-button-highlight {
-  0% {
-    box-shadow: inset 0 0 0 999px rgba(123, 242, 216, 0.22);
-    filter: brightness(1.2);
-  }
-  100% {
-    box-shadow: inset 0 0 0 999px rgba(123, 242, 216, 0);
-    filter: brightness(1);
-  }
+button:active {
+  transform: translateY(1px) scale(0.99);
+  border-color: rgba(125, 211, 252, 0.98);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.95), inset 0 0 20px rgba(43, 120, 255, 0.55);
+  background: rgba(10, 24, 40, 0.78);
 }
 
 input,

--- a/src/libs/ui_v2/ui.ts
+++ b/src/libs/ui_v2/ui.ts
@@ -6,26 +6,9 @@ import { Menu } from './Menu';
 import { SectionManager } from './SectionManager';
 import { AppOptions } from './types';
 
-function attachThumbButtonHighlight(): void {
-  const trigger = (eventTarget: EventTarget | null) => {
-    if (!(eventTarget instanceof Element)) return;
-    const button = eventTarget.closest("[data-overlay='thumb'] button");
-    if (!(button instanceof HTMLButtonElement)) return;
-    button.classList.remove('thumb-button-active');
-    // Force reflow so repeated taps retrigger animation.
-    void button.offsetWidth;
-    button.classList.add('thumb-button-active');
-  };
-
-  document.addEventListener('click', (event) => {
-    trigger(event.target);
-  });
-}
-
 export function setupApp(options: AppOptions = {}) {
   const sections = new SectionManager({ debug: options.debug ?? true });
   const menu = new Menu();
-  attachThumbButtonHighlight();
 
   if (options.title) {
     const titleEl = document.querySelector('[aria-label="App Header"] h1');

--- a/src/plugins/dag/src_v3/ui/index.html
+++ b/src/plugins/dag/src_v3/ui/index.html
@@ -23,7 +23,7 @@
         <div aria-label="Global Menu Panel" hidden></div>
       </nav>
 
-      <section id="dag-table" aria-label="DAG Table Section">
+      <section id="dag-meta-table" aria-label="DAG Table Section">
         <table aria-label="DAG Table">
           <thead>
             <tr>
@@ -34,11 +34,23 @@
           </thead>
           <tbody></tbody>
         </table>
-        <div class="dag-table-thumb" aria-hidden="true"></div>
+        <form data-mode-form="table" aria-label="Table Mode Form">
+          <button type="button" aria-label="Table Thumb 1">1:Refresh</button>
+          <button type="button" aria-label="Table Thumb 2">2:Up</button>
+          <button type="button" aria-label="Table Thumb 3">3:Down</button>
+          <button type="button" aria-label="Table Thumb 4">4:Top</button>
+          <button type="button" aria-label="Table Thumb 5">5:Bottom</button>
+          <button type="button" aria-label="Table Thumb 6">6:Stage</button>
+          <button type="button" aria-label="Table Thumb 7">7:Log</button>
+          <button type="button" aria-label="Table Thumb 8">8:Clear</button>
+          <button type="button" aria-label="Table Mode">9:Mode: Browse</button>
+          <input type="text" aria-label="Table Query Input" placeholder="Filter table rows" />
+          <button type="button" aria-label="Table Submit">10:Apply</button>
+        </form>
         <aside class="dag-table-legend" aria-hidden="true"></aside>
       </section>
 
-      <section id="three" aria-label="Three Section" hidden>
+      <section id="dag-3d-stage" aria-label="Three Section" hidden>
         <canvas aria-label="Three Canvas"></canvas>
         <div class="dag-history" aria-label="DAG Node History">
           <h3>Node History 1/1</h3>
@@ -63,22 +75,40 @@
             <code aria-label="DAG Node History Item 5">none</code>
           </div>
         </div>
-        <div class="dag-controls" aria-label="DAG Controls Grid">
-          <div class="dag-chatlog" aria-label="DAG Chatlog Overlay">
+        <form data-mode-form="dag" aria-label="DAG Mode Form">
+          <aside class="dag-chatlog" aria-label="DAG Chatlog Overlay">
             <div class="dag-chatlog-xterm" aria-label="DAG Chatlog Terminal"></div>
-          </div>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 1">Back</button>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 2">Add</button>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 3">Link</button>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 4">Clear</button>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 5">open</button>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 6">Rename</button>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 7">Focus</button>
-          <button type="button" class="dag-thumb dag-action-btn" aria-label="DAG Thumb 8">Labels On</button>
-          <button type="button" class="dag-thumb dag-mode-thumb" aria-label="DAG Mode">Mode: Graph</button>
-          <input class="dag-label-input" type="text" aria-label="DAG Label Input" placeholder="Select node to rename" />
-          <button type="button" class="dag-rename-btn" aria-label="DAG Rename">Submit</button>
-        </div>
+          </aside>
+          <button type="button" aria-label="DAG Thumb 1">1:Back</button>
+          <button type="button" aria-label="DAG Thumb 2">2:Add</button>
+          <button type="button" aria-label="DAG Thumb 3">3:Link</button>
+          <button type="button" aria-label="DAG Thumb 4">4:Clear</button>
+          <button type="button" aria-label="DAG Thumb 5">5:Open</button>
+          <button type="button" aria-label="DAG Thumb 6">6:Rename</button>
+          <button type="button" aria-label="DAG Thumb 7">7:Focus</button>
+          <button type="button" aria-label="DAG Thumb 8">8:Labels On</button>
+          <button type="button" aria-label="DAG Mode">9:Mode: Graph</button>
+          <input type="text" aria-label="DAG Label Input" placeholder="Select node to rename" />
+          <button type="button" aria-label="DAG Rename">10:Submit</button>
+        </form>
+      </section>
+
+      <section id="dag-log-xterm" aria-label="Log Section" hidden>
+        <div aria-label="Log Terminal"></div>
+        <form data-mode-form="log" aria-label="Log Mode Form">
+          <button type="button" aria-label="Log Thumb 1">1:Left</button>
+          <button type="button" aria-label="Log Thumb 2">2:Right</button>
+          <button type="button" aria-label="Log Thumb 3">3:Up</button>
+          <button type="button" aria-label="Log Thumb 4">4:Down</button>
+          <button type="button" aria-label="Log Thumb 5">5:Home</button>
+          <button type="button" aria-label="Log Thumb 6">6:End</button>
+          <button type="button" aria-label="Log Thumb 7">7:Select</button>
+          <button type="button" aria-label="Log Thumb 8">8:Copy</button>
+          <button type="button" aria-label="Log Mode">9:Mode: Cursor</button>
+          <input type="text" aria-label="Log Command Input" placeholder="Type command for log terminal" />
+          <button type="button" aria-label="Log Submit">10:Submit</button>
+        </form>
+        <aside class="dag-log-legend" aria-hidden="true"></aside>
       </section>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/src/plugins/dag/src_v3/ui/src/components/table/index.ts
+++ b/src/plugins/dag/src_v3/ui/src/components/table/index.ts
@@ -6,16 +6,31 @@ type TableRow = {
   status: string;
 };
 
+type TableMode = 'browse' | 'filter';
+
 class TableControl implements VisualizationControl {
   private allRows: TableRow[] = [];
+  private visibleRows: TableRow[] = [];
+  private selectedIndex = 0;
+  private mode: TableMode = 'browse';
   private loadPromise: Promise<void> | null = null;
   private lastLoadFailed = false;
   private retryBlockedUntil = 0;
   private readonly apiReadyStorageKey = 'dag.src_v3.api_ready';
 
-  constructor(private container: HTMLElement) {}
+  private form: HTMLFormElement | null = null;
+  private modeButton: HTMLButtonElement | null = null;
+  private actionButtons: HTMLButtonElement[] = [];
+  private input: HTMLInputElement | null = null;
+  private submitButton: HTMLButtonElement | null = null;
 
-  dispose(): void {}
+  constructor(private container: HTMLElement) {
+    this.bindModeForm();
+  }
+
+  dispose(): void {
+    // no-op
+  }
 
   private getElements() {
     const table = this.container.querySelector("table[aria-label='DAG Table']") as HTMLTableElement | null;
@@ -24,36 +39,190 @@ class TableControl implements VisualizationControl {
     return { table, tbody };
   }
 
+  private escapeHTML(value: string): string {
+    return value
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
   private renderRows(rows: TableRow[]): void {
     const { tbody } = this.getElements();
     if (!tbody) return;
     tbody.innerHTML = rows
-      .map((r) => `<tr><td>${r.key}</td><td>${r.value}</td><td>${r.status}</td></tr>`)
+      .map((r, idx) => {
+        const selected = idx === this.selectedIndex ? 'true' : 'false';
+        return `<tr data-selected="${selected}"><td>${this.escapeHTML(r.key)}</td><td>${this.escapeHTML(r.value)}</td><td>${this.escapeHTML(r.status)}</td></tr>`;
+      })
       .join('');
   }
 
-  private renderAllRows(): void {
+  private renderVisibleRows(): void {
     const { table, tbody } = this.getElements();
     if (!table || !tbody) return;
-    if (this.allRows.length === 0) return;
+    this.selectedIndex = Math.max(0, Math.min(this.selectedIndex, Math.max(0, this.visibleRows.length - 1)));
     table.setAttribute('data-total-rows', String(this.allRows.length));
-    table.setAttribute('data-visible-rows', String(this.allRows.length));
-    this.renderRows(this.allRows);
+    table.setAttribute('data-visible-rows', String(this.visibleRows.length));
+    this.renderRows(this.visibleRows);
+    this.scrollSelectedRowIntoView();
+  }
+
+  private scrollSelectedRowIntoView(): void {
+    const { tbody } = this.getElements();
+    if (!tbody) return;
+    const selected = tbody.querySelector("tr[data-selected='true']") as HTMLTableRowElement | null;
+    selected?.scrollIntoView({ block: 'nearest' });
+  }
+
+  private applyFilterFromInput(): void {
+    const q = (this.input?.value ?? '').trim().toLowerCase();
+    if (!q) {
+      this.visibleRows = [...this.allRows];
+      this.selectedIndex = 0;
+      this.renderVisibleRows();
+      return;
+    }
+    this.visibleRows = this.allRows.filter((row) => {
+      const hay = `${row.key} ${row.value} ${row.status}`.toLowerCase();
+      return hay.includes(q);
+    });
+    this.selectedIndex = 0;
+    this.renderVisibleRows();
+  }
+
+  private moveSelection(delta: number): void {
+    if (this.visibleRows.length === 0) return;
+    const next = this.selectedIndex + delta;
+    this.selectedIndex = Math.max(0, Math.min(this.visibleRows.length - 1, next));
+    this.renderVisibleRows();
+  }
+
+  private setSelection(index: number): void {
+    if (this.visibleRows.length === 0) return;
+    this.selectedIndex = Math.max(0, Math.min(this.visibleRows.length - 1, index));
+    this.renderVisibleRows();
+  }
+
+  private gotoSection(hash: '#dag-3d-stage' | '#dag-log-xterm'): void {
+    if (window.location.hash !== hash) window.location.hash = hash;
+  }
+
+  private cycleMode(): void {
+    this.mode = this.mode === 'browse' ? 'filter' : 'browse';
+    this.syncForm();
+  }
+
+  private actionSet(): Array<{ label: string; aria: string; run: () => void | Promise<void> }> {
+    if (this.mode === 'filter') {
+      return [
+        { label: 'Refresh', aria: 'Refresh', run: () => void this.reload() },
+        { label: 'Apply', aria: 'Apply', run: () => this.applyFilterFromInput() },
+        {
+          label: 'Clear',
+          aria: 'Clear',
+          run: () => {
+            if (this.input) this.input.value = '';
+            this.applyFilterFromInput();
+          },
+        },
+        { label: 'Top', aria: 'Top', run: () => this.setSelection(0) },
+        { label: 'Bottom', aria: 'Bottom', run: () => this.setSelection(this.visibleRows.length - 1) },
+        { label: 'Stage', aria: 'Stage', run: () => this.gotoSection('#dag-3d-stage') },
+        { label: 'Log', aria: 'Log', run: () => this.gotoSection('#dag-log-xterm') },
+        { label: 'Down', aria: 'Down', run: () => this.moveSelection(1) },
+      ];
+    }
+    return [
+      { label: 'Refresh', aria: 'Refresh', run: () => void this.reload() },
+      { label: 'Up', aria: 'Up', run: () => this.moveSelection(-1) },
+      { label: 'Down', aria: 'Down', run: () => this.moveSelection(1) },
+      { label: 'Top', aria: 'Top', run: () => this.setSelection(0) },
+      { label: 'Bottom', aria: 'Bottom', run: () => this.setSelection(this.visibleRows.length - 1) },
+      { label: 'Stage', aria: 'Stage', run: () => this.gotoSection('#dag-3d-stage') },
+      { label: 'Log', aria: 'Log', run: () => this.gotoSection('#dag-log-xterm') },
+      {
+        label: 'Clear',
+        aria: 'Clear',
+        run: () => {
+          if (this.input) this.input.value = '';
+          this.applyFilterFromInput();
+        },
+      },
+    ];
+  }
+
+  private syncForm(): void {
+    const actions = this.actionSet();
+    for (let i = 0; i < this.actionButtons.length; i += 1) {
+      const action = actions[i];
+      const button = this.actionButtons[i];
+      if (!action || !button) continue;
+      button.textContent = `${i + 1}:${action.label}`;
+      button.setAttribute('aria-label', action.aria);
+      button.onclick = () => {
+        void action.run();
+      };
+    }
+    if (this.modeButton) {
+      this.modeButton.textContent = `9:Mode: ${this.mode === 'browse' ? 'Browse' : 'Filter'}`;
+      this.modeButton.setAttribute('data-mode', this.mode);
+    }
+    if (this.input) {
+      this.input.placeholder = this.mode === 'browse' ? 'Filter table rows' : 'Filter key/value/status';
+    }
+    if (this.submitButton) {
+      this.submitButton.textContent = '10:Apply';
+    }
+  }
+
+  private bindModeForm(): void {
+    this.form = this.container.querySelector("form[data-mode-form='table']") as HTMLFormElement | null;
+    if (!this.form) return;
+    this.modeButton = this.form.querySelector("button[aria-label='Table Mode']") as HTMLButtonElement | null;
+    this.input = this.form.querySelector("input[aria-label='Table Query Input']") as HTMLInputElement | null;
+    this.submitButton = this.form.querySelector("button[aria-label='Table Submit']") as HTMLButtonElement | null;
+    this.actionButtons = [
+      this.form.querySelector("button[aria-label='Table Thumb 1']"),
+      this.form.querySelector("button[aria-label='Table Thumb 2']"),
+      this.form.querySelector("button[aria-label='Table Thumb 3']"),
+      this.form.querySelector("button[aria-label='Table Thumb 4']"),
+      this.form.querySelector("button[aria-label='Table Thumb 5']"),
+      this.form.querySelector("button[aria-label='Table Thumb 6']"),
+      this.form.querySelector("button[aria-label='Table Thumb 7']"),
+      this.form.querySelector("button[aria-label='Table Thumb 8']"),
+    ].filter((el): el is HTMLButtonElement => !!el);
+
+    this.modeButton?.addEventListener('click', () => this.cycleMode());
+    this.submitButton?.addEventListener('click', () => this.applyFilterFromInput());
+    this.form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this.applyFilterFromInput();
+    });
+    this.input?.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      this.applyFilterFromInput();
+    });
+
+    this.syncForm();
   }
 
   setVisible(visible: boolean): void {
     const table = this.container.querySelector("table[aria-label='DAG Table']") as HTMLTableElement | null;
     if (!table) return;
     if (visible) {
+      this.syncForm();
       if (Date.now() < this.retryBlockedUntil) {
-        this.renderAllRows();
+        this.renderVisibleRows();
         table.setAttribute('data-ready', this.lastLoadFailed ? 'error' : 'true');
         return;
       }
       if (this.allRows.length === 0 || this.lastLoadFailed) {
         void this.ensureRowsLoaded(table);
       } else {
-        this.renderAllRows();
+        this.renderVisibleRows();
         table.setAttribute('data-ready', 'true');
       }
     }
@@ -124,19 +293,29 @@ class TableControl implements VisualizationControl {
     throw lastErr ?? new Error('failed to load dag table');
   }
 
+  private async reload(): Promise<void> {
+    const { table } = this.getElements();
+    if (!table) return;
+    await this.loadRows(table);
+  }
+
   private async loadRows(table: HTMLTableElement): Promise<void> {
     table.setAttribute('data-ready', 'loading');
     try {
       this.allRows = await this.fetchRowsWithRetry();
       this.lastLoadFailed = false;
-      this.renderAllRows();
+      this.visibleRows = [...this.allRows];
+      this.selectedIndex = 0;
+      this.renderVisibleRows();
       table.setAttribute('data-ready', 'true');
     } catch (err) {
       console.error('[DAG Table] query failed', err);
       this.lastLoadFailed = true;
       this.retryBlockedUntil = Date.now() + 5000;
       this.allRows = this.getFallbackRows();
-      this.renderAllRows();
+      this.visibleRows = [...this.allRows];
+      this.selectedIndex = 0;
+      this.renderVisibleRows();
       table.setAttribute('data-ready', 'error');
     }
   }

--- a/src/plugins/dag/src_v3/ui/src/style.css
+++ b/src/plugins/dag/src_v3/ui/src/style.css
@@ -1,29 +1,31 @@
 @import '../../../../../libs/ui_v2/style.css';
 
-section[aria-label='DAG Table Section'],
-section[aria-label='Three Section'] {
+#dag-meta-table,
+#dag-3d-stage {
   display: grid;
   place-items: stretch;
 }
 
-section[aria-label='DAG Table Section'] {
+#dag-meta-table {
   --table-row-height: 1.45em;
-  overflow-y: auto;
+  grid-template-rows: minmax(0, 1fr) auto;
+  overflow: hidden;
   -webkit-overflow-scrolling: touch;
   padding: 0;
 }
 
-section[aria-label='DAG Table Section'] table {
+#dag-meta-table table {
+  grid-row: 1;
   display: table;
   width: 100%;
   height: auto;
-  background: #090f18;
+  background: #000;
   align-self: stretch;
   table-layout: fixed;
 }
 
-section[aria-label='DAG Table Section'] th,
-section[aria-label='DAG Table Section'] td {
+#dag-meta-table th,
+#dag-meta-table td {
   height: var(--table-row-height);
   padding: 0 0.6em;
   line-height: 1.45em;
@@ -32,12 +34,23 @@ section[aria-label='DAG Table Section'] td {
   text-overflow: ellipsis;
 }
 
-.dag-table-thumb,
+#dag-meta-table td {
+  color: #c8cdd6;
+}
+
+#dag-meta-table th {
+  padding: 0.35em 0.9em;
+}
+
+#dag-meta-table tbody tr[data-selected='true'] {
+  background: rgba(56, 60, 66, 0.55);
+}
+
 .dag-table-legend {
   display: none;
 }
 
-section[aria-label='Three Section'] {
+#dag-3d-stage {
   background: #000;
   position: relative;
 }
@@ -63,7 +76,7 @@ nav > button.thumb {
   background: rgba(9, 14, 24, 0.94);
 }
 
-canvas[aria-label='Three Canvas'] {
+#dag-3d-stage canvas {
   width: 100vw;
   height: 100vh;
   border: 0;
@@ -122,20 +135,46 @@ canvas[aria-label='Three Canvas'] {
 .swatch.recent-2 { background: #2b78ff; }
 .swatch.history { background: #475261; }
 
-.dag-controls {
+form {
+  width: min(500px, calc(100vw - 28px));
+  max-width: 500px;
+  --mode-form-gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(56px, 1fr));
+  grid-template-rows: 84px repeat(4, minmax(56px, auto));
+  gap: var(--mode-form-gap);
+  z-index: 11;
+  pointer-events: auto;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+#dag-3d-stage form,
+#dag-log-xterm form {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  width: min(500px, calc(100vw - 28px));
-  max-width: 500px;
   bottom: calc(env(safe-area-inset-bottom, 0px) + 14px);
-  --dag-controls-gap: 12px;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(56px, 1fr));
-  grid-template-rows: 84px repeat(3, minmax(56px, auto)) 46px;
-  gap: var(--dag-controls-gap);
-  z-index: 11;
-  pointer-events: auto;
+}
+
+#dag-meta-table form {
+  grid-row: 2;
+  position: relative;
+  left: auto;
+  transform: none;
+  bottom: auto;
+  width: 100%;
+  max-width: none;
+  padding: 14px;
+}
+
+form[data-mode-form='log'] {
+  grid-template-rows: repeat(4, minmax(56px, auto));
+}
+
+form[data-mode-form='table'] {
+  grid-template-rows: repeat(4, minmax(56px, auto));
 }
 
 .dag-chatlog {
@@ -145,7 +184,7 @@ canvas[aria-label='Three Canvas'] {
   height: 100%;
   display: flex;
   align-items: flex-end;
-  margin-bottom: calc(-1 * var(--dag-controls-gap));
+  margin-bottom: calc(-1 * var(--mode-form-gap));
   pointer-events: none;
   background: transparent;
 }
@@ -184,12 +223,12 @@ canvas[aria-label='Three Canvas'] {
 .dag-chatlog-xterm .xterm-rows > div:nth-last-child(6) { opacity: 0.58; }
 .dag-chatlog-xterm .xterm-rows > div:nth-last-child(7) { opacity: 0.5; }
 
-.dag-controls > .dag-thumb {
+form > button {
   width: 100%;
   min-width: 56px;
   height: 64px;
   min-height: 56px;
-  border-radius: 8px;
+  border-radius: 3px;
   border: 1px solid rgba(240, 246, 255, 0.55);
   background: rgba(0, 0, 0, 0.5);
   color: #f2f7ff;
@@ -199,17 +238,23 @@ canvas[aria-label='Three Canvas'] {
   touch-action: manipulation;
 }
 
-.dag-controls > .dag-thumb.is-active {
+form > button.is-active {
   border-color: rgba(125, 211, 252, 0.95);
   box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.8), inset 0 0 16px rgba(43, 120, 255, 0.42);
   background: rgba(8, 20, 34, 0.72);
 }
 
-.dag-controls > .dag-label-input {
-  grid-row: 5;
-  grid-column: 1 / span 2;
+form > button:focus-visible,
+form > input:focus-visible {
+  border-color: rgba(125, 211, 252, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.8), inset 0 0 16px rgba(43, 120, 255, 0.42);
+  background: rgba(8, 20, 34, 0.72);
+  outline: 0;
+}
+
+form > input {
   width: 100%;
-  height: 46px;
+  height: 64px;
   border-radius: 8px;
   border: 1px solid rgba(240, 246, 255, 0.45);
   background: rgba(0, 0, 0, 0.5);
@@ -217,17 +262,60 @@ canvas[aria-label='Three Canvas'] {
   padding: 0 12px;
 }
 
-.dag-controls > .dag-mode-thumb {
+form[data-mode-form='dag'] > input {
+  grid-row: 5;
+  grid-column: 1 / span 2;
+}
+
+form[data-mode-form='log'] > input {
+  grid-row: 4;
+  grid-column: 1 / span 2;
+}
+
+form[data-mode-form='table'] > input {
+  grid-row: 4;
+  grid-column: 1 / span 2;
+}
+
+form > button:nth-of-type(9) {
   border-color: rgba(147, 197, 253, 0.85);
   background: rgba(5, 19, 42, 0.72);
 }
 
-.dag-controls > .dag-rename-btn {
+form > input:focus { outline: 0; }
+
+form[data-mode-form='log'] > button:last-of-type {
+  grid-row: 4;
+  grid-column: 3;
+  width: 100%;
+  height: 64px;
+  border-radius: 3px;
+  border: 1px solid rgba(240, 246, 255, 0.55);
+  background: rgba(0, 0, 0, 0.5);
+  color: #f2f7ff;
+  text-align: center;
+  font-weight: 700;
+}
+
+form[data-mode-form='table'] > button:last-of-type {
+  grid-row: 4;
+  grid-column: 3;
+  width: 100%;
+  height: 64px;
+  border-radius: 3px;
+  border: 1px solid rgba(240, 246, 255, 0.55);
+  background: rgba(0, 0, 0, 0.5);
+  color: #f2f7ff;
+  text-align: center;
+  font-weight: 700;
+}
+
+form[data-mode-form='dag'] > button:last-of-type {
   grid-row: 5;
   grid-column: 3;
   width: 100%;
-  height: 46px;
-  border-radius: 8px;
+  height: 64px;
+  border-radius: 3px;
   border: 1px solid rgba(240, 246, 255, 0.55);
   background: rgba(0, 0, 0, 0.5);
   color: #f2f7ff;
@@ -236,7 +324,50 @@ canvas[aria-label='Three Canvas'] {
 }
 
 @media (max-width: 420px) {
-  .dag-thumb {
+  form > button {
     height: 60px;
   }
+}
+
+#dag-log-xterm {
+  position: relative;
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  background: #000;
+}
+
+#dag-log-xterm > div:first-child {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+#dag-log-xterm > div:first-child .xterm,
+#dag-log-xterm > div:first-child .xterm-viewport,
+#dag-log-xterm > div:first-child .xterm-screen,
+#dag-log-xterm > div:first-child .xterm-rows,
+#dag-log-xterm > div:first-child .xterm-scroll-area {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+#dag-log-xterm > div:first-child .xterm-rows {
+  display: flex !important;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+#dag-log-xterm > div:first-child .xterm-rows > div {
+  flex: 0 0 auto;
+}
+
+.dag-log-legend {
+  display: none;
 }

--- a/src/plugins/dag/ui-design.md
+++ b/src/plugins/dag/ui-design.md
@@ -1,0 +1,63 @@
+# DAG UI Design Notes (`src_v3`)
+
+## Goals
+
+- Reduce CSS surface area and selector churn.
+- Prefer semantic HTML (`section`, `nav`, `form`, `aside`) over class-heavy wrappers.
+- Make `mode-form` the primary control abstraction for section overlays.
+- Keep behavior stable by preserving aria labels used by tests.
+
+## Naming Rules
+
+- Section IDs use: `<plugin-name>-<subname>-<underlay-type>`.
+- Valid underlay types in UI v2: `stage`, `table`, `docs`, `xterm`, `video`.
+- Current DAG section IDs:
+  - `dag-meta-table`
+  - `dag-3d-stage`
+  - `dag-log-xterm`
+- Control overlays use `mode-form` (not `thumbs`).
+
+## Implemented Changes
+
+- Stage and log control overlays are now semantic forms:
+  - `form.mode-form[data-mode-form='dag']`
+  - `form.mode-form[data-mode-form='log']`
+- Removed per-button class dependency in markup (`dag-thumb`, `dag-action-btn`, etc.).
+- CSS now styles controls primarily through structure:
+  - `form.mode-form > button`
+  - `form.mode-form > input`
+  - `form.mode-form > button[aria-label$='Mode']`
+- Overlay binding in section registration now targets forms directly.
+- Existing aria labels were kept so test flows continue to work.
+
+## CSS Simplification Pattern
+
+- Prefer low-specificity structural selectors.
+- Avoid one-off button classes when aria already identifies role.
+- Keep only domain-specific classes where structure alone is insufficient:
+  - `dag-history`
+  - `dag-chatlog`
+  - `dag-chatlog-xterm`
+
+## Recommended Next Steps
+
+- Replace remaining DAG-prefixed spacing token names with generic UI tokens.
+- Move shared `mode-form` styles to `src/libs/ui_v2/style.css` once another plugin adopts it.
+- Normalize underlay section aria labels to include section ID for easier debugging.
+- Add a tiny section-style checklist to PR template:
+  - semantic wrapper tag
+  - `mode-form` for mode-driven controls
+  - no redundant button classes
+  - aria stability for tests
+
+## Testing Expectations
+
+After UI structure changes, run:
+
+```bash
+./dialtone.sh dag lint src_v3
+./dialtone.sh dag build src_v3
+./dialtone.sh dag test src_v3 --attach
+```
+
+This validates compile/build and live section navigation/control behavior.


### PR DESCRIPTION
## Summary\n- simplify DAG v3 UI controls around semantic  overlays\n- add table section mode-form controls and two-row table layout (table top, form bottom)\n- make  the modal container when menu opens\n- unify default button styling to black base + blue highlight\n- refresh DAG/UI docs for naming and mode-form conventions\n\n## Files\n- src/plugins/dag/src_v3/ui/index.html\n- src/plugins/dag/src_v3/ui/src/main.ts\n- src/plugins/dag/src_v3/ui/src/style.css\n- src/plugins/dag/src_v3/ui/src/components/table/index.ts\n- src/libs/ui_v2/Menu.ts\n- src/libs/ui_v2/style.css\n- src/libs/ui_v2/ui.ts\n- src/plugins/dag/README.md\n- src/plugins/dag/ui-design.md\n- src/libs/ui_v2/README.md\n\n## Validation\n- ./dialtone.sh dag build src_v3\n