### PR TITLE
dag v3: shader glow + stateful view camera offset controls

### DIFF
--- a/src/plugins/dag/src_v3/test/03.go
+++ b/src/plugins/dag/src_v3/test/03.go
@@ -10,12 +10,9 @@ func Run03ThreeUserStoryStartEmpty(ctx *testCtx) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Println("[THREE] story step1 description:")
-	fmt.Println("[THREE]   - In order to create a new node, the user taps Add.")
-	fmt.Println("[THREE]   - The user starts from an empty DAG in root layer and expects one selected node after add.")
-	fmt.Println("[THREE]   - Camera expectation: zoomed-out root framing with room for upcoming input/output nodes.")
-	ctx.appendThought("story step1: load stage and verify controls are visible")
-	if err := ctx.navigate(ctx.appURL("/#three")); err != nil {
+	ctx.logf("STORY> step 1: computer A program node")
+	ctx.logf("STORY> user opens stage, adds first node, and names it Program A")
+	if err := ctx.navigate(ctx.appURL("/#dag-3d-stage")); err != nil {
 		return "", err
 	}
 	if err := ctx.waitAria("Three Canvas", "need stage canvas before interactions"); err != nil {
@@ -27,13 +24,7 @@ func Run03ThreeUserStoryStartEmpty(ctx *testCtx) (string, error) {
 	if err := ctx.waitAria("DAG Mode", "need mode button"); err != nil {
 		return "", err
 	}
-	if err := ctx.waitAria("DAG Thumb 1", "need thumb 1"); err != nil {
-		return "", err
-	}
-	if err := ctx.waitAria("DAG Thumb 2", "need thumb 2"); err != nil {
-		return "", err
-	}
-	if err := ctx.waitAria("DAG Thumb 3", "need thumb 3"); err != nil {
+	if err := ctx.waitAria("DAG Add", "need add thumb action"); err != nil {
 		return "", err
 	}
 	if err := ctx.waitAria("DAG Label Input", "need rename input"); err != nil {
@@ -47,24 +38,21 @@ func Run03ThreeUserStoryStartEmpty(ctx *testCtx) (string, error) {
 	}
 	id, err := ctx.lastCreatedNodeID()
 	if err != nil || id == "" {
-		return "", fmt.Errorf("story step1 failed: missing processor id")
+		return "", fmt.Errorf("step1 failed: missing node id")
 	}
-	ctx.story.ProcessorID = id
-	if err := ctx.clickAction("camera", "camera_top"); err != nil {
+	ctx.story.AProgramID = id
+	if err := ctx.renameSelectedNoModeSwitch("Program A"); err != nil {
 		return "", err
 	}
-	if err := ctx.clickAction("camera", "camera_side"); err != nil {
+	if err := ctx.assertProjectedInCanvas(ctx.story.AProgramID); err != nil {
 		return "", err
 	}
-	if err := ctx.clickAction("camera", "camera_iso"); err != nil {
-		return "", err
-	}
-	if err := ctx.clickNode(ctx.story.ProcessorID); err != nil {
+	if err := ctx.assertNodeCameraDistance(ctx.story.AProgramID, 27, 4); err != nil {
 		return "", err
 	}
 	ctx.logClick("step_done", "story_step_1", "ok")
 	if err := ctx.captureShot("test_step_2.png"); err != nil {
 		return "", fmt.Errorf("capture story step1 screenshot: %w", err)
 	}
-	return "Loaded the stage controls, added the first node, cycled camera modes (top/side/iso), and reselected the new node to verify interaction readiness.", nil
+	return "Created and labeled the root `Program A` node, then validated camera/node projection from unified logs.", nil
 }

--- a/src/plugins/dag/src_v3/test/11_mode_coverage.go
+++ b/src/plugins/dag/src_v3/test/11_mode_coverage.go
@@ -1,0 +1,166 @@
+package main
+
+import "fmt"
+
+func Run11SwitchToBuildMode(ctx *testCtx) (string, error) {
+	if err := ctx.ensureMode("graph"); err != nil {
+		return "", err
+	}
+	if err := ctx.assertMode("graph"); err != nil {
+		return "", err
+	}
+	return "Confirmed the thumb calculator is in Build mode.", nil
+}
+
+func Run11BuildModeCoverageA(ctx *testCtx) (string, error) {
+	if err := ctx.clickAction("graph", "add"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("graph", "link_or_unlink"); err != nil {
+		return "", err
+	}
+	if err := ctx.setRenameInput("Build Relay"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("graph", "rename"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("graph", "focus"); err != nil {
+		return "", err
+	}
+	id, err := ctx.lastCreatedNodeID()
+	if err != nil || id == "" {
+		return "", fmt.Errorf("build coverage A missing created node id")
+	}
+	if err := ctx.assertProjectedInCanvas(id); err != nil {
+		return "", err
+	}
+	return "Build mode used `Add`, `Link/Unlink`, `Rename`, and `Focus` with viewport projection validation.", nil
+}
+
+func Run11BuildModeCoverageB(ctx *testCtx) (string, error) {
+	if err := ctx.clickAction("graph", "open_or_close_layer"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("graph", "back"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("graph", "toggle_labels"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("graph", "clear_picks"); err != nil {
+		return "", err
+	}
+	if err := ctx.assertActiveLayer("root"); err != nil {
+		return "", err
+	}
+	return "Build mode used `Open/Close`, `Back`, `Labels`, and `Clear`, and verified root-layer state.", nil
+}
+
+func Run12SwitchToLayerMode(ctx *testCtx) (string, error) {
+	if err := ctx.ensureMode("layer"); err != nil {
+		return "", err
+	}
+	if err := ctx.assertMode("layer"); err != nil {
+		return "", err
+	}
+	return "Confirmed the thumb calculator is in Layer mode.", nil
+}
+
+func Run13LayerModeCoverageA(ctx *testCtx) (string, error) {
+	if err := ctx.clickAction("layer", "add"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("layer", "link_or_unlink"); err != nil {
+		return "", err
+	}
+	if err := ctx.setRenameInput("Layer Relay"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("layer", "rename"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("layer", "focus"); err != nil {
+		return "", err
+	}
+	id, err := ctx.lastCreatedNodeID()
+	if err != nil || id == "" {
+		return "", fmt.Errorf("layer coverage A missing created node id")
+	}
+	if err := ctx.assertProjectedInCanvas(id); err != nil {
+		return "", err
+	}
+	return "Layer mode used `Add`, `Link/Unlink`, `Rename`, and `Focus` on a relay node with viewport projection validation.", nil
+}
+
+func Run14LayerModeCoverageB(ctx *testCtx) (string, error) {
+	if err := ctx.clickAction("layer", "open_or_close_layer"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("layer", "back"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("layer", "toggle_labels"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("layer", "clear_picks"); err != nil {
+		return "", err
+	}
+	if err := ctx.assertActiveLayer("root"); err != nil {
+		return "", err
+	}
+	return "Layer mode used `Open/Close`, `Back`, `Labels`, and `Clear`, and confirmed return to the root layer.", nil
+}
+
+func Run15SwitchToCameraMode(ctx *testCtx) (string, error) {
+	if err := ctx.clickAria("DAG Mode", "switch layer controls to view controls"); err != nil {
+		return "", err
+	}
+	if err := ctx.assertMode("camera"); err != nil {
+		return "", err
+	}
+	return "Switched the thumb calculator from Layer mode to View mode.", nil
+}
+
+func Run16CameraModeCoverageA(ctx *testCtx) (string, error) {
+	if err := ctx.clickAction("camera", "camera_top"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("camera", "camera_iso"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("camera", "camera_side"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("camera", "focus"); err != nil {
+		return "", err
+	}
+	return "View mode used camera orientation controls `Top`, `Iso`, `Side`, then `Focus` to reframe the active layer.", nil
+}
+
+func Run17CameraModeCoverageB(ctx *testCtx) (string, error) {
+	if err := ctx.clickAction("camera", "camera_left"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("camera", "camera_up"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("camera", "camera_right"); err != nil {
+		return "", err
+	}
+	if err := ctx.clickAction("camera", "camera_down"); err != nil {
+		return "", err
+	}
+	return "View mode used stateful camera offset controls `Left`, `Up`, `Right`, and `Down`.", nil
+}
+
+func Run18FinalizeAndTeardown(ctx *testCtx) (string, error) {
+	if err := ctx.clickAria("DAG Mode", "return to build mode before teardown"); err != nil {
+		return "", err
+	}
+	if err := ctx.assertMode("graph"); err != nil {
+		return "", err
+	}
+	ctx.teardown()
+	return "Returned controls to Build mode and tore down shared browser/backend resources.", nil
+}

--- a/src/plugins/dag/src_v3/ui/index.html
+++ b/src/plugins/dag/src_v3/ui/index.html
@@ -47,7 +47,7 @@
           <input type="text" aria-label="Table Query Input" placeholder="Filter table rows" />
           <button type="button" aria-label="Table Submit">10:Apply</button>
         </form>
-        <aside class="dag-table-legend" aria-hidden="true"></aside>
+        <aside class="dag-table-legend" aria-label="DAG Table Legend" aria-hidden="true"></aside>
       </section>
 
       <section id="dag-3d-stage" aria-label="Three Section" hidden>
@@ -108,7 +108,7 @@
           <input type="text" aria-label="Log Command Input" placeholder="Type command for log terminal" />
           <button type="button" aria-label="Log Submit">10:Submit</button>
         </form>
-        <aside class="dag-log-legend" aria-hidden="true"></aside>
+        <aside class="dag-log-legend" aria-label="DAG Log Legend" aria-hidden="true"></aside>
       </section>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/src/plugins/dag/src_v3/ui/src/components/three/camera.ts
+++ b/src/plugins/dag/src_v3/ui/src/components/three/camera.ts
@@ -19,7 +19,16 @@ export class DagStageCamera {
     }
   }
 
-  framePoint(center: THREE.Vector3, maxDim: number, view: DagCameraView) {
+  private applyPanOffset(panX: number, panY: number) {
+    if (Math.abs(panX) < 0.0001 && Math.abs(panY) < 0.0001) return;
+    this.camera.updateMatrixWorld(true);
+    const right = new THREE.Vector3(1, 0, 0).applyQuaternion(this.camera.quaternion);
+    const up = new THREE.Vector3(0, 1, 0).applyQuaternion(this.camera.quaternion);
+    const delta = right.multiplyScalar(-panX).add(up.multiplyScalar(panY));
+    this.camera.position.add(delta);
+  }
+
+  framePoint(center: THREE.Vector3, maxDim: number, view: DagCameraView, panX = 0, panY = 0) {
     const fov = THREE.MathUtils.degToRad(this.camera.fov);
     const aspectScale = this.camera.aspect < 1 ? 1 / this.camera.aspect : 1;
     const dist = ((maxDim * aspectScale) / (2 * Math.tan(fov / 2))) * 1.2 + 14;
@@ -27,14 +36,16 @@ export class DagStageCamera {
     target.y += this.lookYOffset;
     this.applyViewPosition(center, dist, view);
     this.camera.lookAt(target);
+    this.applyPanOffset(panX, panY);
     this.camera.updateProjectionMatrix();
   }
 
-  framePointFixed(center: THREE.Vector3, fixedDistance: number, view: DagCameraView) {
+  framePointFixed(center: THREE.Vector3, fixedDistance: number, view: DagCameraView, panX = 0, panY = 0) {
     const target = center.clone();
     target.y += this.lookYOffset;
     this.applyViewPosition(center, fixedDistance, view);
     this.camera.lookAt(target);
+    this.applyPanOffset(panX, panY);
     this.camera.updateProjectionMatrix();
   }
 }


### PR DESCRIPTION
## Summary\n- add shader-based pulse glow for selected DAG node\n- change view mode button layout to include directional camera offset controls:\n  - 4: Left, 5: Up, 6: Right, 8: Down\n- make camera offsets stateful so pan is preserved across focus/layer/view reframes\n- keep selectors aria-driven in DAG test helpers and add missing legend aria labels\n\n## Validation\n- ./dialtone.sh dag build src_v3\n- go build ./src/plugins/dag/src_v3/test\n- ./dialtone.sh dag test src_v3 --attach (previously run in-session after aria label fixes; passed full suite)