### PR TITLE
DAG v3: modeForm overlay key + history dedupe

### DIFF
--- a/src/plugins/dag/src_v3/ui/src/components/three/index.ts
+++ b/src/plugins/dag/src_v3/ui/src/components/three/index.ts
@@ -904,6 +904,12 @@ class ThreeControl implements VisualizationControl {
     this.selectedNodeId = nodeId;
     if (nodeId) {
       this.recentSelectedNodeIDs.unshift(nodeId);
+      // Keep history useful for link/back operations by collapsing immediate repeats.
+      for (let i = this.recentSelectedNodeIDs.length - 1; i > 0; i -= 1) {
+        if (this.recentSelectedNodeIDs[i] === this.recentSelectedNodeIDs[i - 1]) {
+          this.recentSelectedNodeIDs.splice(i, 1);
+        }
+      }
       if (this.recentSelectedNodeIDs.length > 5) this.recentSelectedNodeIDs.length = 5;
       console.log(`[Three #three] selected node: ${nodeId}`);
       this.focusCameraOnNode(nodeId);

--- a/src/plugins/dag/src_v3/ui/src/main.ts
+++ b/src/plugins/dag/src_v3/ui/src/main.ts
@@ -40,7 +40,7 @@ sections.register('dag-meta-table', {
   overlays: {
     primaryKind: 'table',
     primary: "table[aria-label='DAG Table']",
-    thumb: "form[data-mode-form='table']",
+    modeForm: "form[data-mode-form='table']",
     legend: '.dag-table-legend',
   },
 });
@@ -57,7 +57,7 @@ sections.register('dag-3d-stage', {
   overlays: {
     primaryKind: 'stage',
     primary: "canvas[aria-label='Three Canvas']",
-    thumb: "form[data-mode-form='dag']",
+    modeForm: "form[data-mode-form='dag']",
     legend: '.dag-history',
     chatlog: '.dag-chatlog',
   },
@@ -75,7 +75,7 @@ sections.register('dag-log-xterm', {
   overlays: {
     primaryKind: 'xterm',
     primary: "[aria-label='Log Terminal']",
-    thumb: "form[data-mode-form='log']",
+    modeForm: "form[data-mode-form='log']",
     legend: '.dag-log-legend',
   },
 });


### PR DESCRIPTION
## Summary
- switch DAG v3 section overlay config from deprecated `thumb` to `modeForm`
- dedupe immediate repeated node selections in recent history list

## Files
- src/plugins/dag/src_v3/ui/src/main.ts
- src/plugins/dag/src_v3/ui/src/components/three/index.ts
