### PR TITLE
Docs: add README template and improve main README onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,133 @@
-# [`DIALTONE`](https://dialtone.earth)
-> IMPORTANT: This should sound like something from a science fiction novel about the near future of civic technology.
+# [`DIALTONE`](https://dialtone.earth) `https://dialtone.earth`
+> A shared software system for learning, coordination, and real-world community work.
 
-![dialtone](./dialtone.jpg)
+![dialtone](./src/plugins/www/screenshots/summary.png)
 
-## Website
-[dialtone.earth](https://dialtone.earth)
+## REPL / Chat Interface (Target)
+`./dialtone.sh` should move to a simple text-chat REPL with a `DIALTONE>` prompt, following [DIALTONE.md](./DIALTONE.md) and [RLM_DIALTONE.md](./RLM_DIALTONE.md).  
+Users and agents submit role-based commands (for example `USER-1>`), and command output is streamed back as `DIALTONE:PID:>`.
 
-## Getting Started
-
-### Windows
-Run commands using the `dialtone.cmd` wrapper (no PowerShell policy issues):
-```cmd
-.\dialtone --help
+Example:
+```text
+USER-1> ps all
+DIALTONE> Request received. Sign with `@DIALTONE task --sign current-task` to run.
+USER-1> @DIALTONE task --sign current-task
+DIALTONE> Signatures verified. Running command via PID 4512...
+DIALTONE:4512> PID  USER  CMD
+DIALTONE:4512> 4512 user  dialtone
+DIALTONE> Process 4512 exited with code 0.
 ```
 
-### Linux / WSL / macOS
-Run commands using `dialtone.sh`:
+## `PERSONA>` Model
+Dialtone uses explicit speaking roles in the REPL so every line has a clear source.
+
+- `DIALTONE>`: the core orchestrator process.
+- `DIALTONE:PID>`: a Dialtone subtone/subprocess stream (per running task/process).
+- `USER-1>` (and other `USER-*` roles): cryptographically signed user identities.
+- `LLM-*>`: dynamically created LLM agent subprocesses orchestrated by `DIALTONE>`, similar to subtones but specialized for reasoning/planning/tool use.
+
+This makes command intent, authorization, and runtime output easy to audit in one shared session.
+
+## Logs (TODO: `libs/logs_v1`)
+Dialtone should add a shared logging library at `src/libs/logs_v1` to standardize local/dev/prod logs across plugins and services.
+
+Planned log levels:
+- `--quiet` (minimal output)
+- `--verbose` (operator-friendly detail)
+- `--debug` (full diagnostic detail)
+
+Goal: same log format everywhere, with strong defaults for command history, process lifecycle, errors, and API call summaries.
+
+## Telemetry and Trace (TODO)
+Dialtone should add telemetry/tracing so operators can follow activity across the network and inspect end-to-end latency.
+
+Planned behavior:
+- `--trace` turns on distributed tracing for requests, function calls, and API hops.
+- Trace output links events to logs so one request can be followed across services.
+- Telemetry captures live production signals like CPU stats, memory, latencies, versions, and other runtime metrics needed for analysis.
+
+## Getting Started
+The easiest way to get started is `https://dialtone.earth`.
+
+### Clone and Run
+```bash
+git clone https://github.com/dialtone/dialtone.git
+cd dialtone
+./dialtone.sh
+```
+
+### Run on Windows
+```powershell
+./dialtone.ps1 --help
+```
+
+### Run on Linux / WSL / macOS
 ```bash
 ./dialtone.sh --help
 ```
 
-## What is Dialtone?
-Dialtone is a public information system for civic coordination and education. It connects people, tools, and knowledge to solve real-world problems.
+## What Dialtone Is
+Dialtone is a small program that runs on computers, phones, and robots. It is built for small communities that need practical tools for learning, planning, and operations.
 
-- **A Virtual Librarian**: Guides students and builders through mathematics, physics, and engineering using real-world examples.
-- **Civic Coordination**: Tools for city councils and teams to plan, budget, and track public projects.
-- **Shared Infrastructure**: A network of publicly owned robots, radios, and sensors that anyone can learn from and build upon.
-- **Live Operations**: Real-time maps and status dashboards for tracking active missions and deployed hardware.
-- **Open Marketplace**: Connects operators with parts, services, and training needed to keep systems running.
-- **Secure Identity**: Cryptographic tools for managing keys, identity, and access to shared resources.
+- It acts like a virtual librarian for civic coordination and education.
+- It can build interactive 3D spaces to work with users.
+- Mesh radios and local networks help people and robots communicate.
+- It has a plugin system so teams can extend functionality safely.
+- It can adapt to new tasks by distilling and fine-tuning focused sub-models.
+- It combines systems like CAD, BIM, ERP, GIS, and related workflows into one pattern.
+- It includes plugins for testing, development, and deployment.
+- It supports a robotics and manufacturing marketplace for parts, services, and data.
+- It is open to contributors who want to build skills in robotics, math, manufacturing, and more.
+
+## Code Stack
+### DAG Plugin
+The DAG plugin is the main source of truth for current UI/interaction patterns, section naming, overlays, and test flow. Agents should start here to understand how the system is expected to behave at runtime.  
+README: [src/plugins/dag/README.md](src/plugins/dag/README.md)
+
+### Template Plugin
+The template plugin is the reusable starter for building new plugins with the same lifecycle, section model, and dev/test commands. It mirrors production patterns in a simpler package.  
+README: [src/plugins/template/README.md](src/plugins/template/README.md)
+
+### UI Library (`ui_v2`)
+`ui_v2` provides shared primitives for section lifecycle, menu handling, overlay/underlay wiring, and URL-driven navigation. Plugin UIs should compose these building blocks instead of re-implementing them.  
+README: [src/libs/ui_v2/README.md](src/libs/ui_v2/README.md)
+
+### Test Library (`test_v2`)
+`test_v2` provides browser/session orchestration, aria-label-driven actions, logging, and screenshot/report helpers for deterministic UI tests. Use it to keep plugin validation behavior consistent across the repo.  
+README: [src/libs/test_v2/README.md](src/libs/test_v2/README.md)
+
+## How the code base is organized
+- `./dialtone.sh` and `.\dialtone.ps1` start a REPL with `DIALTONE>`
+- `src/dev.go` is the main entry for the Command Line Interface (CLI)
+- golang is used to scaffold the rest of the code base
+- `src/plugins/` contains the plugins for the program
+- plugins are the main way to extend `DIALTONE>`
+- `env/.env` contains the environment variables for the program
+
+- `src/libs/` contains the shared libraries for the program
+- `src/plugins/` contains the plugins for the program
+- `src/skills/` contains the skills for the program
+- `src/tools/` contains the tools for the program
+- `src/tests/` contains the tests for the program
+- `src/examples/` contains the examples for the program
+- `src/docs/` contains the documentation for the program
+- `src/examples/` contains the examples for the program
+- writing code with `DIALTONE>`
 
 ## Who uses Dialtone
-- **Students**: Use the virtual library to learn mathematics, physics, and engineering through guided problems tied to real systems.
-- **City councils and civic teams**: Plan new public spaces, coordinate contractors, and monitor ongoing work.
-- **Builders and operators**: Assemble radio and robot kits, run missions, and ship improvements.
-- **Developers**: Contribute documentation, tests, and code to the platform.
+- Manufacturers building production and sensor systems.
+- Students learning math, physics, and engineering with real examples.
+- Civic teams planning public projects and tracking progress.
+- Builders and operators assembling kits and running field work.
+- Developers writing code, docs, and tests.
+- Researchers running experiments and monitoring live data.
+
+### README.md
+Every plugin must include a `README.md` at its plugin root (`src/plugins/<plugin>/README.md`).
+
+Use the shared template:
+
+- [README_TEMPLATE.md](./README_TEMPLATE.md)
 
 ## DIALTONE example session log
 ```text

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -1,0 +1,40 @@
+# Plugin README Template
+
+Use this template for every plugin README at:
+
+- `src/plugins/<plugin>/README.md`
+
+## Test Summary
+- Show status: `PASS` or `FAIL`.
+- If `FAIL`, include the first error and stack trace.
+- Keep this section near the top so contributors can quickly see plugin health.
+
+## Section Screenshot Grid
+- Provide a compact screenshot grid for each UI section.
+- Label each screenshot with section id or section name.
+- Use this section for fast visual verification after test runs.
+
+## Shell help
+- Include shell usage examples in a code block.
+- Include at least:
+- `dev`
+- `build`
+- `test`
+- plugin-specific commands
+
+Example:
+```bash
+./dialtone.sh <plugin> dev <src_vN>
+./dialtone.sh <plugin> build <src_vN>
+./dialtone.sh <plugin> test <src_vN>
+```
+
+## Workflow
+- Explain how to develop and validate changes for this plugin.
+- Include:
+- local dev flow
+- test flow
+- how to read failures
+- how to refresh screenshots/reports
+- checks for shared libraries when relevant (`src/libs/ui_v2`, `src/libs/test_v2`, future `src/libs/logs_v1`)
+- cross-plugin validation when shared patterns must stay aligned


### PR DESCRIPTION
## Summary
- rework top-level README into clearer plain-language onboarding sections
- add REPL role model docs for `DIALTONE>`, `DIALTONE:PID>`, `USER-*>`, and `LLM-*>`
- add TODO sections for logs (`src/libs/logs_v1`) and telemetry/trace (`--trace`, `--quiet`, `--verbose`, `--debug`)
- move plugin README requirements into a dedicated `README_TEMPLATE.md`
- link template from `README.md` using a GitHub-safe relative path

## Files
- README.md
- README_TEMPLATE.md
