### PR TITLE
REPL service install mode, auto-update, and NATS bus flow

### DIFF
--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -142,7 +142,7 @@ Status stream examples:
 ## REPL Foundation Order
 
 `repl src_v1 test` is organized bottom-up so foundational plugins validate first via real REPL subtone execution:
-- `01_repl_core`: REPL-only behavior (help, input handling, line format)
+- `01_repl_core`: REPL-only behavior (help, hostname prompt input handling, line format)
 - `02_proc_plugin`: `proc src_v1 test`
 - `03_logs_plugin`: `logs src_v1 test`
 - `04_test_plugin`: `test src_v1 test`

--- a/src/plugins/github/src_v1/go/github.go
+++ b/src/plugins/github/src_v1/go/github.go
@@ -110,6 +110,8 @@ func Run(args []string) error {
 		return nil
 	case "install":
 		return runInstall()
+	case "release":
+		return runRelease(args[1:])
 	case "issue", "issues":
 		return runIssue(args[1:])
 	case "pr":
@@ -135,6 +137,7 @@ func PrintUsage() {
 	fmt.Println("  pr push [src_v1] [--out DIR] [--force]")
 	fmt.Println("  pr print [src_v1] <pr-id> [--out DIR]")
 	fmt.Println("  pr [src_v1] [create|view|merge|close|review] [args]")
+	fmt.Println("  release upsert [src_v1] --tag vX.Y.Z [--repo owner/repo] [--title TEXT] [--notes TEXT] --asset PATH [--asset PATH...]")
 	fmt.Println("  test [src_v1]")
 	fmt.Println("  install")
 }
@@ -151,6 +154,94 @@ func runInstall() error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func runRelease(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ./dialtone.sh github release upsert --tag <version> [--repo owner/repo] [--title text] [--notes text] --asset <path> [--asset <path>...]")
+	}
+	args = stripVersionArg(args)
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ./dialtone.sh github release upsert --tag <version> [--repo owner/repo] [--title text] [--notes text] --asset <path> [--asset <path>...]")
+	}
+	if args[0] != "upsert" {
+		return fmt.Errorf("unknown release command: %s", args[0])
+	}
+
+	tag := ""
+	repo := "timcash/dialtone"
+	title := ""
+	notes := ""
+	assets := make([]string, 0, 8)
+
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--tag":
+			if i+1 < len(args) {
+				tag = strings.TrimSpace(args[i+1])
+				i++
+			}
+		case "--repo":
+			if i+1 < len(args) {
+				repo = strings.TrimSpace(args[i+1])
+				i++
+			}
+		case "--title":
+			if i+1 < len(args) {
+				title = args[i+1]
+				i++
+			}
+		case "--notes":
+			if i+1 < len(args) {
+				notes = args[i+1]
+				i++
+			}
+		case "--asset":
+			if i+1 < len(args) {
+				assets = append(assets, args[i+1])
+				i++
+			}
+		}
+	}
+	if tag == "" {
+		return fmt.Errorf("missing --tag")
+	}
+	if len(assets) == 0 {
+		return fmt.Errorf("at least one --asset is required")
+	}
+	if title == "" {
+		title = "Release " + tag
+	}
+	if notes == "" {
+		notes = "Automated release " + tag
+	}
+	for _, a := range assets {
+		if _, err := os.Stat(a); err != nil {
+			return fmt.Errorf("missing asset %s: %w", a, err)
+		}
+	}
+
+	gh := findGH()
+	createArgs := []string{"release", "create", tag, "--repo", repo, "--title", title, "--notes", notes}
+	createArgs = append(createArgs, assets...)
+	create := exec.Command(gh, createArgs...)
+	create.Stdout = os.Stdout
+	create.Stderr = os.Stderr
+	if err := create.Run(); err == nil {
+		logs.Info("Created release %s on %s", tag, repo)
+		return nil
+	}
+
+	uploadArgs := []string{"release", "upload", tag, "--repo", repo, "--clobber"}
+	uploadArgs = append(uploadArgs, assets...)
+	upload := exec.Command(gh, uploadArgs...)
+	upload.Stdout = os.Stdout
+	upload.Stderr = os.Stderr
+	if err := upload.Run(); err != nil {
+		return fmt.Errorf("release create failed and upload fallback failed: %w", err)
+	}
+	logs.Info("Updated existing release %s on %s", tag, repo)
+	return nil
 }
 
 func runIssue(args []string) error {

--- a/src/plugins/logs/src_v1/test/TEST.md
+++ b/src/plugins/logs/src_v1/test/TEST.md
@@ -1,7 +1,7 @@
 # Test Report: logs-src-v1
 
-- **Date**: Sun, 22 Feb 2026 10:19:39 PST
-- **Total Duration**: 2.054660206s
+- **Date**: Sun, 22 Feb 2026 12:32:19 PST
+- **Total Duration**: 2.135516532s
 
 ## Summary
 
@@ -12,35 +12,35 @@
 
 ### 1. ✅ 01 Embedded NATS + topic publish
 
-- **Duration**: 2.258845ms
+- **Duration**: 3.669642ms
 - **Report**: NATS messages verified at nats://127.0.0.1:4222.
 
 ---
 
 ### 2. ✅ 02 Listener filtering (error.topic)
 
-- **Duration**: 1.418728ms
+- **Duration**: 1.063153ms
 - **Report**: Verified error-topic filtering via NATS
 
 ---
 
 ### 3. ✅ 04 Two-process pingpong via dialtone logs
 
-- **Duration**: 1.128589514s
+- **Duration**: 1.175248404s
 - **Report**: Verified two dialtone logs processes exchanged 3 ping/pong rounds on one topic.
 
 ---
 
 ### 4. ✅ 05 Example plugin binary imports logs library
 
-- **Duration**: 921.469898ms
+- **Duration**: 954.435127ms
 - **Report**: Verified example plugin binary imports logs library and publishes expected messages.
 
 ---
 
 ### 5. ✅ 03 Finalize artifacts
 
-- **Duration**: 904.282µs
+- **Duration**: 1.044225ms
 - **Report**: Suite finalized. Verification transitioned to NATS topics.
 
 ---

--- a/src/plugins/repl/README.md
+++ b/src/plugins/repl/README.md
@@ -1,13 +1,61 @@
 # REPL Plugin
 
-The REPL plugin tests interactive `dialtone.sh` behavior (`USER-1>` / `DIALTONE>` flow).
+The REPL plugin provides:
+- local interactive REPL (`run`)
+- shared multi-client REPL over NATS (`serve`/`join`)
+- update-aware service supervisor (`service`)
+- release build/publish tooling for per-architecture binaries (`release`)
+
+Prompts default to host identity (`<hostname>`) instead of `USER-1`.
 
 ## CLI
 ```bash
 ./dialtone.sh repl src_v1 help
+./dialtone.sh repl src_v1 run
+./dialtone.sh repl src_v1 status
+./dialtone.sh repl src_v1 serve --nats-url nats://0.0.0.0:4222 --room main --embedded-nats
+./dialtone.sh repl src_v1 join --nats-url nats://<server-ip>:4222 --room main --name <hostname>
+./dialtone.sh repl src_v1 service --mode run --repo timcash/dialtone --nats-url nats://0.0.0.0:4222 --room main --check-interval 3m
+./dialtone.sh repl src_v1 build
+./dialtone.sh repl src_v1 release build v0.1.0
+./dialtone.sh repl src_v1 release publish v0.1.0 timcash/dialtone
 ./dialtone.sh repl src_v1 test
 ```
 
+## NATS Model
+- REPL bus uses one subject per room: `repl.<room>`.
+- User input is published as NATS `input` frames first.
+- Server (`DIALTONE`) listens on that same subject and executes input frames.
+- REPL stdout is replay from NATS `line`/`server` frames.
+- Clients can detect an already-running server via probe/heartbeat frames on the same subject.
+
+## Standalone Binary
+```bash
+./dialtone.sh repl src_v1 build
+.dialtone/bin/repl-src_v1 serve --nats-url nats://0.0.0.0:4222 --room main --embedded-nats
+.dialtone/bin/repl-src_v1 join --nats-url nats://<server-ip>:4222 --room main --name <hostname>
+.dialtone/bin/repl-src_v1 service --mode run --repo timcash/dialtone --nats-url nats://0.0.0.0:4222 --room main
+```
+
+## Release Artifacts
+`release build <version>` creates:
+- `repl-src_v1-linux-amd64`
+- `repl-src_v1-linux-arm64`
+- `repl-src_v1-darwin-amd64`
+- `repl-src_v1-darwin-arm64`
+- `repl-src_v1-windows-amd64.exe`
+
+`release publish` uploads those binaries to a GitHub release tag.
+
+## Service Hot-Swap
+`service --mode run` acts as a stable supervisor daemon:
+- checks GitHub Releases every interval
+- downloads newer architecture-matched worker binary
+- stops old worker subprocess
+- starts new worker subprocess
+- keeps supervisor process alive during swap
+
+## Tests
 `repl src_v1 test` runs:
 - `src/plugins/repl/src_v1/test/cmd/main.go`
 - `src/plugins/repl/src_v1/test/01_repl_core/suite.go`
@@ -16,22 +64,3 @@ The REPL plugin tests interactive `dialtone.sh` behavior (`USER-1>` / `DIALTONE>
 - `src/plugins/repl/src_v1/test/04_test_plugin/suite.go`
 - `src/plugins/repl/src_v1/test/05_chrome_plugin/suite.go`
 - `src/plugins/repl/src_v1/test/06_go_bun_plugins/suite.go`
-
-Current suite coverage:
-- `01_repl_core`
-  - verifies REPL-only behavior: help text correctness, input handling, `USER-1>`/`DIALTONE>` line formatting
-- `02_proc_plugin`
-  - runs `proc src_v1 test` through REPL subtone flow
-- `03_logs_plugin`
-  - runs `logs src_v1 test` through REPL subtone flow
-- `04_test_plugin`
-  - runs `test src_v1 test` through REPL subtone flow
-- `05_chrome_plugin`
-  - runs `chrome src_v1 list` through REPL subtone flow
-- `06_go_bun_plugins`
-  - runs `go src_v1 test` then `bun src_v1 test` through REPL subtone flow
-
-## Notes
-- REPL tests are implemented with shared `test` plugin (`testv1.StepContext`) and `logs` plugin (`logs/src_v1/go`) patterns.
-- Suites are arranged bottom-up and execute foundational plugin checks via REPL-managed subtones.
-- REPL commands are entered directly (for example `logs src_v1 test`); no `@DIALTONE` prefix is used.

--- a/src/plugins/repl/scaffold/main.go
+++ b/src/plugins/repl/scaffold/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	logs "dialtone/dev/plugins/logs/src_v1/go"
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
 )
 
 func main() {
@@ -18,7 +19,7 @@ func main() {
 		return
 	}
 
-	version, command, warnedOldOrder, err := parseArgs(args)
+	version, command, rest, warnedOldOrder, err := parseArgs(args)
 	if err != nil {
 		logs.Error("%v", err)
 		printUsage()
@@ -27,11 +28,50 @@ func main() {
 	if warnedOldOrder {
 		logs.Warn("old repl CLI order is deprecated. Use: ./dialtone.sh repl src_v1 <command> [args]")
 	}
+	if version != "src_v1" {
+		logs.Error("Unsupported repl version: %s", version)
+		os.Exit(1)
+	}
 
 	switch command {
 	case "test":
 		if err := runVersionedTest(version); err != nil {
 			logs.Error("REPL test error: %v", err)
+			os.Exit(1)
+		}
+	case "run":
+		if err := repl.RunLocal(nil, rest); err != nil {
+			logs.Error("repl run failed: %v", err)
+			os.Exit(1)
+		}
+	case "serve":
+		if err := repl.RunServe(rest); err != nil {
+			logs.Error("repl serve failed: %v", err)
+			os.Exit(1)
+		}
+	case "join":
+		if err := repl.RunJoin(rest); err != nil {
+			logs.Error("repl join failed: %v", err)
+			os.Exit(1)
+		}
+	case "status":
+		if err := repl.RunStatus(rest); err != nil {
+			logs.Error("repl status failed: %v", err)
+			os.Exit(1)
+		}
+	case "service":
+		if err := repl.RunService(rest); err != nil {
+			logs.Error("repl service failed: %v", err)
+			os.Exit(1)
+		}
+	case "build":
+		if err := buildStandaloneBinary("", "", ""); err != nil {
+			logs.Error("repl build failed: %v", err)
+			os.Exit(1)
+		}
+	case "release":
+		if err := runRelease(rest); err != nil {
+			logs.Error("repl release failed: %v", err)
 			os.Exit(1)
 		}
 	case "help", "-h", "--help":
@@ -43,23 +83,23 @@ func main() {
 	}
 }
 
-func parseArgs(args []string) (version, command string, warnedOldOrder bool, err error) {
+func parseArgs(args []string) (version, command string, rest []string, warnedOldOrder bool, err error) {
 	if len(args) == 0 {
-		return "", "", false, fmt.Errorf("missing arguments")
+		return "", "", nil, false, fmt.Errorf("missing arguments")
 	}
 	if isHelp(args[0]) {
-		return "src_v1", "help", false, nil
+		return "src_v1", "help", nil, false, nil
 	}
 	if strings.HasPrefix(args[0], "src_v") {
 		if len(args) < 2 {
-			return "", "", false, fmt.Errorf("missing command (usage: ./dialtone.sh repl src_v1 <command> [args])")
+			return "", "", nil, false, fmt.Errorf("missing command (usage: ./dialtone.sh repl src_v1 <command> [args])")
 		}
-		return args[0], args[1], false, nil
+		return args[0], args[1], args[2:], false, nil
 	}
 	if len(args) >= 2 && strings.HasPrefix(args[1], "src_v") {
-		return args[1], args[0], true, nil
+		return args[1], args[0], args[2:], true, nil
 	}
-	return "", "", false, fmt.Errorf("expected version as first repl argument (usage: ./dialtone.sh repl src_v1 <command> [args])")
+	return "", "", nil, false, fmt.Errorf("expected version as first repl argument (usage: ./dialtone.sh repl src_v1 <command> [args])")
 }
 
 func isHelp(s string) bool {
@@ -67,18 +107,9 @@ func isHelp(s string) bool {
 }
 
 func runVersionedTest(versionDir string) error {
-	cwd, _ := os.Getwd()
-	root := cwd
-	for {
-		if _, err := os.Stat(filepath.Join(root, "dialtone.sh")); err == nil {
-			break
-		}
-		parent := filepath.Dir(root)
-		if parent == root {
-			root = cwd
-			break
-		}
-		root = parent
+	root, err := findRepoRoot()
+	if err != nil {
+		return err
 	}
 
 	testPkg := "./plugins/repl/" + versionDir + "/test/cmd/main.go"
@@ -88,13 +119,175 @@ func runVersionedTest(versionDir string) error {
 	cmd.Dir = root
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 	return cmd.Run()
+}
+
+func buildStandaloneBinary(version, goos, goarch string) error {
+	root, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+	binDir := filepath.Join(root, ".dialtone", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return err
+	}
+	name := "repl-src_v1"
+	if goos != "" && goarch != "" {
+		name = fmt.Sprintf("repl-src_v1-%s-%s", goos, goarch)
+		if goos == "windows" {
+			name += ".exe"
+		}
+	}
+	out := filepath.Join(binDir, name)
+	pkg := "./plugins/repl/src_v1/cmd/repld/main.go"
+	ld := ""
+	if strings.TrimSpace(version) != "" {
+		ld = "-X dialtone/dev/plugins/repl/src_v1/go/repl.BuildVersion=" + version
+	}
+
+	goBin := filepath.Join(logs.GetDialtoneEnv(), "go", "bin", "go")
+	if _, err := os.Stat(goBin); err != nil {
+		if fallback, lookErr := exec.LookPath("go"); lookErr == nil {
+			goBin = fallback
+		} else {
+			return fmt.Errorf("managed go binary not found at %s and fallback go not in PATH", goBin)
+		}
+	}
+	args := []string{"build"}
+	if ld != "" {
+		args = append(args, "-ldflags", ld)
+	}
+	args = append(args, "-o", out, pkg)
+
+	cmd := exec.Command(goBin, args...)
+	cmd.Dir = filepath.Join(root, "src")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	if goos != "" {
+		cmd.Env = append(cmd.Env, "GOOS="+goos)
+	}
+	if goarch != "" {
+		cmd.Env = append(cmd.Env, "GOARCH="+goarch)
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	logs.Raw("Built standalone REPL binary: %s", out)
+	return nil
+}
+
+func runRelease(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing release subcommand (build|publish)")
+	}
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "build":
+		return releaseBuild(rest)
+	case "publish":
+		return releasePublish(rest)
+	default:
+		return fmt.Errorf("unknown release subcommand: %s", sub)
+	}
+}
+
+func releaseBuild(args []string) error {
+	version := ""
+	if len(args) > 0 {
+		version = strings.TrimSpace(args[0])
+	}
+	if version == "" {
+		return fmt.Errorf("usage: ./dialtone.sh repl src_v1 release build <version>")
+	}
+	targets := [][2]string{{"linux", "amd64"}, {"linux", "arm64"}, {"darwin", "amd64"}, {"darwin", "arm64"}, {"windows", "amd64"}}
+	for _, t := range targets {
+		if err := buildStandaloneBinary(version, t[0], t[1]); err != nil {
+			return err
+		}
+	}
+	logs.Info("Built release binaries for %s", version)
+	return nil
+}
+
+func releasePublish(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ./dialtone.sh repl src_v1 release publish <version> [repo]")
+	}
+	version := strings.TrimSpace(args[0])
+	repo := "timcash/dialtone"
+	if len(args) > 1 && strings.TrimSpace(args[1]) != "" {
+		repo = strings.TrimSpace(args[1])
+	}
+	root, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+	binDir := filepath.Join(root, ".dialtone", "bin")
+	assets := []string{
+		"repl-src_v1-linux-amd64",
+		"repl-src_v1-linux-arm64",
+		"repl-src_v1-darwin-amd64",
+		"repl-src_v1-darwin-arm64",
+		"repl-src_v1-windows-amd64.exe",
+	}
+	for _, a := range assets {
+		if _, err := os.Stat(filepath.Join(binDir, a)); err != nil {
+			return fmt.Errorf("missing asset %s (run release build first)", a)
+		}
+	}
+
+	githubArgs := []string{"github", "release", "upsert", "src_v1", "--tag", version, "--repo", repo, "--title", "REPL " + version, "--notes", "Automated REPL release " + version}
+	for _, a := range assets {
+		githubArgs = append(githubArgs, "--asset", filepath.Join(binDir, a))
+	}
+	cmd := exec.Command(filepath.Join(root, "dialtone.sh"), githubArgs...)
+	cmd.Dir = root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	logs.Info("Published release %s to %s", version, repo)
+	return nil
+}
+
+func findRepoRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(cwd, "dialtone.sh")); err == nil {
+			return cwd, nil
+		}
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			return "", fmt.Errorf("repo root not found")
+		}
+		cwd = parent
+	}
 }
 
 func printUsage() {
 	logs.Raw("Usage: ./dialtone.sh repl src_v1 <command> [args]")
 	logs.Raw("")
 	logs.Raw("Commands:")
-	logs.Raw("  test                     Run REPL src_v1 tests")
-	logs.Raw("  help                     Show this help")
+	logs.Raw("  run [--name HOST]                                    Run local REPL session")
+	logs.Raw("  serve [--nats-url URL] [--room NAME] [--embedded-nats] [--tsnet] [--hostname HOST]")
+	logs.Raw("                                                       Start shared REPL host/service")
+	logs.Raw("  join [--nats-url URL] [--room NAME] [--name HOST]   Join a shared REPL host")
+	logs.Raw("  status [--nats-url URL] [--room NAME]               Show NATS/tsnet/chrome status")
+	logs.Raw("  service [--mode install|run|status] [--repo owner/repo] [--nats-url URL] [--room NAME] [--check-interval 3m]")
+	logs.Raw("                                                       install: register persistent OS service (default)")
+	logs.Raw("                                                       run: start supervisor in foreground")
+	logs.Raw("                                                       status: print OS service status")
+	logs.Raw("  build                                                Build standalone repl-src_v1 binary")
+	logs.Raw("  release build <version>                              Build per-architecture release binaries")
+	logs.Raw("  release publish <version> [owner/repo]              Publish binaries to GitHub release")
+	logs.Raw("  test                                                 Run REPL src_v1 tests")
+	logs.Raw("  help                                                 Show this help")
 }

--- a/src/plugins/repl/src_v1/cmd/repld/main.go
+++ b/src/plugins/repl/src_v1/cmd/repld/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+
+	logs "dialtone/dev/plugins/logs/src_v1/go"
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
+)
+
+func main() {
+	logs.SetOutput(os.Stdout)
+
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	args := os.Args[2:]
+	var err error
+
+	switch cmd {
+	case "run":
+		err = repl.RunLocal(nil, args)
+	case "serve":
+		err = repl.RunServe(args)
+	case "join":
+		err = repl.RunJoin(args)
+	case "status":
+		err = repl.RunStatus(args)
+	case "service":
+		err = repl.RunService(args)
+	case "version":
+		logs.Raw("%s", repl.BuildVersion)
+		return
+	case "help", "-h", "--help":
+		printUsage()
+		return
+	default:
+		printUsage()
+		os.Exit(1)
+	}
+
+	if err != nil {
+		logs.Error("repld %s failed: %v", cmd, err)
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	logs.Raw("Usage: repl-src_v1 <command> [args]")
+	logs.Raw("")
+	logs.Raw("Commands:")
+	logs.Raw("  run [--name HOST]")
+	logs.Raw("  serve [--nats-url URL] [--room NAME] [--embedded-nats] [--tsnet] [--hostname HOST]")
+	logs.Raw("  join [--nats-url URL] [--room NAME] [--name HOST]")
+	logs.Raw("  status [--nats-url URL] [--room NAME]")
+	logs.Raw("  service [--mode install|run|status] [--repo owner/repo] [--nats-url URL] [--room NAME] [--check-interval 3m]")
+	logs.Raw("  version")
+	logs.Raw("  help")
+}

--- a/src/plugins/repl/src_v1/go/repl/repl.go
+++ b/src/plugins/repl/src_v1/go/repl/repl.go
@@ -2,13 +2,38 @@ package repl
 
 import (
 	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
 	"fmt"
+	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
+	chrome "dialtone/dev/plugins/chrome/src_v1/go"
 	logs "dialtone/dev/plugins/logs/src_v1/go"
 	"dialtone/dev/plugins/proc/src_v1/go/proc"
+	tsnetlib "dialtone/dev/plugins/tsnet/src_v1/go"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	defaultNATSURL = "nats://127.0.0.1:4222"
+	defaultRoom    = "main"
+)
+
+const (
+	frameTypeInput     = "input"
+	frameTypeLine      = "line"
+	frameTypeProbe     = "probe"
+	frameTypeServer    = "server"
+	frameTypeHeartbeat = "heartbeat"
+	frameTypeJoin      = "join"
+	frameTypeLeft      = "left"
 )
 
 type Hooks struct {
@@ -45,19 +70,300 @@ func SetHooksForTest(h Hooks) func() {
 	}
 }
 
+type BusFrame struct {
+	Type      string `json:"type"`
+	From      string `json:"from,omitempty"`
+	Prefix    string `json:"prefix,omitempty"`
+	Message   string `json:"message,omitempty"`
+	ServerID  string `json:"server_id,omitempty"`
+	Timestamp string `json:"timestamp"`
+}
+
+type HostStatus struct {
+	HostName      string `json:"hostname"`
+	NATSURL       string `json:"nats_url"`
+	Room          string `json:"room"`
+	Subject       string `json:"subject"`
+	NATSReachable bool   `json:"nats_reachable"`
+	ServerSeen    bool   `json:"server_seen"`
+	TSNetTailnet  string `json:"tsnet_tailnet"`
+	TSAuthKey     bool   `json:"ts_authkey_present"`
+	TSApiKey      bool   `json:"ts_api_key_present"`
+	ChromeFound   bool   `json:"chrome_found"`
+	ChromePath    string `json:"chrome_path"`
+}
+
 func Start(logFn func(category, msg string)) error {
+	return RunLocal(logFn, nil)
+}
+
+func RunLocal(logFn func(category, msg string), args []string) error {
+	fs := flag.NewFlagSet("repl-run", flag.ContinueOnError)
+	promptName := fs.String("name", DefaultPromptName(), "Prompt name for this session")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if logFn == nil {
+		logFn = func(string, string) {}
+	}
+	return runLocalSession(os.Stdin, os.Stdout, normalizePromptName(*promptName), logFn)
+}
+
+func RunServe(args []string) error {
+	fs := flag.NewFlagSet("repl-serve", flag.ContinueOnError)
+	natsURL := fs.String("nats-url", defaultNATSURL, "NATS URL")
+	room := fs.String("room", defaultRoom, "Shared REPL room")
+	embedded := fs.Bool("embedded-nats", true, "Start embedded NATS on --nats-url")
+	enableTSNet := fs.Bool("tsnet", false, "Start embedded tsnet identity on host")
+	hostname := fs.String("hostname", DefaultPromptName(), "Host name used in prompts")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	nc, broker, usedURL, err := connectNATS(strings.TrimSpace(*natsURL), *embedded)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+	if broker != nil {
+		defer broker.Close()
+	}
+
+	stopTSNet := func() {}
+	if *enableTSNet {
+		cleanup, upErr := startTSNetInstance(normalizePromptName(*hostname))
+		if upErr != nil {
+			logs.Warn("REPL tsnet startup failed: %v", upErr)
+		} else {
+			stopTSNet = cleanup
+		}
+	}
+	defer stopTSNet()
+
+	h := normalizePromptName(*hostname)
+	roomName := sanitizeRoom(*room)
+	subject := replSubject(roomName)
+	serverID := h + "@" + roomName
+
+	publish := func(f BusFrame) {
+		f.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+		f.ServerID = serverID
+		_ = publishFrame(nc, subject, f)
+	}
+
+	// Publish initial presence line to NATS so every connected client sees it.
+	publish(BusFrame{Type: frameTypeServer, Message: fmt.Sprintf("DIALTONE server online on %s (subject=%s nats=%s)", h, subject, usedURL)})
+	logs.Info("REPL host serving: hostname=%s room=%s subject=%s nats=%s", h, roomName, subject, usedURL)
+
+	var runMu sync.Mutex
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		frame, ok := decodeFrame(msg.Data)
+		if !ok {
+			return
+		}
+		printFrame(os.Stdout, frame)
+		switch frame.Type {
+		case frameTypeProbe:
+			publish(BusFrame{Type: frameTypeServer, Message: fmt.Sprintf("DIALTONE server active on %s", h)})
+		case frameTypeInput:
+			go func(in BusFrame) {
+				runMu.Lock()
+				defer runMu.Unlock()
+				executeCommand(strings.TrimSpace(in.Message), func(prefix, msg string) {
+					publish(BusFrame{Type: frameTypeLine, Prefix: prefix, Message: msg})
+				})
+			}(frame)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	defer sub.Unsubscribe()
+	if err := nc.Flush(); err != nil {
+		return err
+	}
+
+	heartbeat := time.NewTicker(5 * time.Second)
+	defer heartbeat.Stop()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	for {
+		select {
+		case <-heartbeat.C:
+			publish(BusFrame{Type: frameTypeHeartbeat, Message: "alive"})
+		case <-sig:
+			publish(BusFrame{Type: frameTypeServer, Message: "DIALTONE server shutting down."})
+			return nil
+		}
+	}
+}
+
+func RunJoin(args []string) error {
+	fs := flag.NewFlagSet("repl-join", flag.ContinueOnError)
+	natsURL := fs.String("nats-url", defaultNATSURL, "NATS URL")
+	room := fs.String("room", defaultRoom, "Shared REPL room")
+	name := fs.String("name", DefaultPromptName(), "Prompt name for this client")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	nc, err := nats.Connect(strings.TrimSpace(*natsURL), nats.Timeout(1500*time.Millisecond))
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	prompt := normalizePromptName(*name)
+	roomName := sanitizeRoom(*room)
+	subject := replSubject(roomName)
+
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		frame, ok := decodeFrame(msg.Data)
+		if !ok {
+			return
+		}
+		printFrame(os.Stdout, frame)
+	})
+	if err != nil {
+		return err
+	}
+	defer sub.Unsubscribe()
+	if err := nc.Flush(); err != nil {
+		return err
+	}
+
+	_ = publishFrame(nc, subject, BusFrame{Type: frameTypeProbe, From: prompt, Message: "probe"})
+	_ = publishFrame(nc, subject, BusFrame{Type: frameTypeJoin, From: prompt, Message: prompt})
+	_ = nc.Flush()
+	fmt.Fprintf(os.Stdout, "DIALTONE> Connected to %s via %s\n", subject, strings.TrimSpace(*natsURL))
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Fprintf(os.Stdout, "%s> ", prompt)
+		if !scanner.Scan() {
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if line == "exit" || line == "quit" {
+			break
+		}
+		if err := publishFrame(nc, subject, BusFrame{Type: frameTypeInput, From: prompt, Message: line}); err != nil {
+			return err
+		}
+		if err := nc.Flush(); err != nil {
+			return err
+		}
+	}
+	_ = publishFrame(nc, subject, BusFrame{Type: frameTypeLeft, From: prompt, Message: prompt})
+	_ = nc.Flush()
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func RunStatus(args []string) error {
+	fs := flag.NewFlagSet("repl-status", flag.ContinueOnError)
+	natsURL := fs.String("nats-url", defaultNATSURL, "NATS URL")
+	room := fs.String("room", defaultRoom, "Shared REPL room")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	roomName := sanitizeRoom(*room)
+	subject := replSubject(roomName)
+	st := HostStatus{
+		HostName: normalizePromptName(DefaultPromptName()),
+		NATSURL:  strings.TrimSpace(*natsURL),
+		Room:     roomName,
+		Subject:  subject,
+	}
+
+	nc, err := nats.Connect(st.NATSURL, nats.Timeout(1200*time.Millisecond))
+	if err == nil {
+		st.NATSReachable = true
+		serverSeen := make(chan bool, 1)
+		sub, subErr := nc.Subscribe(subject, func(msg *nats.Msg) {
+			frame, ok := decodeFrame(msg.Data)
+			if !ok {
+				return
+			}
+			if frame.Type == frameTypeServer || frame.Type == frameTypeHeartbeat {
+				select {
+				case serverSeen <- true:
+				default:
+				}
+			}
+		})
+		if subErr == nil {
+			_ = nc.Flush()
+			_ = publishFrame(nc, subject, BusFrame{Type: frameTypeProbe, From: st.HostName, Message: "status-probe"})
+			select {
+			case <-serverSeen:
+				st.ServerSeen = true
+			case <-time.After(1400 * time.Millisecond):
+			}
+			_ = sub.Unsubscribe()
+		}
+		nc.Close()
+	}
+
+	if cfg, err := tsnetlib.ResolveConfig(st.HostName, ""); err == nil {
+		st.TSNetTailnet = cfg.Tailnet
+		st.TSAuthKey = cfg.AuthKeyPresent
+		st.TSApiKey = cfg.APIKeyPresent
+	}
+	st.ChromePath = strings.TrimSpace(chrome.FindChromePath())
+	st.ChromeFound = st.ChromePath != ""
+
+	logs.Raw("REPL status")
+	logs.Raw("  Hostname: %s", st.HostName)
+	logs.Raw("  NATS URL: %s", st.NATSURL)
+	logs.Raw("  Room: %s", st.Room)
+	logs.Raw("  Subject: %s", st.Subject)
+	logs.Raw("  NATS Reachable: %t", st.NATSReachable)
+	logs.Raw("  DIALTONE Server Seen: %t", st.ServerSeen)
+	logs.Raw("  TS Tailnet: %s", st.TSNetTailnet)
+	logs.Raw("  TS AuthKey Present: %t", st.TSAuthKey)
+	logs.Raw("  TS API Key Present: %t", st.TSApiKey)
+	if st.ChromeFound {
+		logs.Raw("  Chrome: %s", st.ChromePath)
+	} else {
+		logs.Raw("  Chrome: not found")
+	}
+	return nil
+}
+
+func DefaultPromptName() string {
+	host, err := os.Hostname()
+	if err != nil {
+		return "USER-1"
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "USER-1"
+	}
+	return host
+}
+
+func runLocalSession(in io.Reader, out io.Writer, promptName string, logFn func(category, msg string)) error {
 	if logFn == nil {
 		logFn = func(string, string) {}
 	}
 
 	say := func(msg string) {
-		fmt.Println("DIALTONE> " + msg)
-		logs.Info("[REPL] DIALTONE> %s", msg)
-		logFn("REPL", "DIALTONE> "+msg)
+		line := "DIALTONE> " + msg
+		fmt.Fprintln(out, line)
+		logs.Info("[REPL] %s", line)
+		logFn("REPL", line)
 	}
-	saySubtone := func(pid int, msg string) {
-		line := fmt.Sprintf("DIALTONE:%d> %s", pid, msg)
-		fmt.Println(line)
+	sayPrefixed := func(prefix, msg string) {
+		line := fmt.Sprintf("%s> %s", prefix, msg)
+		fmt.Fprintln(out, line)
 		logs.Info("[REPL] %s", line)
 		logFn("REPL", line)
 	}
@@ -65,11 +371,10 @@ func Start(logFn func(category, msg string)) error {
 	say("Virtual Librarian online.")
 	say("Type 'help' for commands, or 'exit' to quit.")
 
-	scanner := bufio.NewScanner(os.Stdin)
-	tty := isTTY()
-
+	scanner := bufio.NewScanner(in)
+	tty := isInputTTY(in)
 	for {
-		fmt.Print("USER-1> ")
+		fmt.Fprintf(out, "%s> ", promptName)
 		if !scanner.Scan() {
 			say("Session closed.")
 			break
@@ -78,150 +383,167 @@ func Start(logFn func(category, msg string)) error {
 		if line == "" {
 			continue
 		}
-
 		if !tty {
-			fmt.Println(line)
+			fmt.Fprintln(out, line)
 		}
-		logFn("REPL", "USER-1> "+line)
-
+		logFn("REPL", fmt.Sprintf("%s> %s", promptName, line))
 		if line == "exit" || line == "quit" {
 			say("Goodbye.")
 			break
 		}
-		if line == "help" {
-			printHelp(logFn)
-			continue
-		}
-		if line == "ps" {
-			printManagedProcesses(say)
-			continue
-		}
-		if strings.HasPrefix(line, "kill ") {
-			pidText := strings.TrimSpace(strings.TrimPrefix(line, "kill"))
-			pid := 0
-			if _, err := fmt.Sscanf(pidText, "%d", &pid); err != nil || pid <= 0 {
-				say("Usage: kill <pid>")
-				continue
-			}
-			if err := killManagedProcessFn(pid); err != nil {
-				say(fmt.Sprintf("Failed to kill process %d: %v", pid, err))
-			} else {
-				say(fmt.Sprintf("Killed managed process %d.", pid))
-			}
-			continue
-		}
-
-		args := strings.Fields(line)
-		if len(args) == 0 {
-			continue
-		}
-
-		cmdName := args[0]
-		if len(args) > 1 {
-			cmdName += " " + args[1]
-		}
-
-		isBackground := false
-		if len(args) > 0 && args[len(args)-1] == "&" {
-			isBackground = true
-			args = args[:len(args)-1]
-			cmdName = strings.TrimSuffix(cmdName, " &")
-		}
-
-		say(fmt.Sprintf("Request received. Spawning subtone for %s...", cmdName))
-		onEvent := func(ev proc.SubtoneEvent) {
-			switch ev.Type {
-			case proc.SubtoneEventStarted:
-				if ev.PID <= 0 {
-					return
-				}
-				saySubtone(ev.PID, fmt.Sprintf("Started at %s", ev.StartedAt.Format(time.RFC3339)))
-				saySubtone(ev.PID, fmt.Sprintf("Command: %v", ev.Args))
-				if strings.TrimSpace(ev.LogPath) != "" {
-					saySubtone(ev.PID, fmt.Sprintf("Log: %s", ev.LogPath))
-				}
-			case proc.SubtoneEventStdout:
-				if ev.PID <= 0 {
-					return
-				}
-				if hasStructuredLevel(ev.Line) {
-					saySubtone(ev.PID, ev.Line)
-				}
-			case proc.SubtoneEventStderr:
-				if ev.PID <= 0 {
-					return
-				}
-				line := strings.TrimSpace(ev.Line)
-				if line == "" {
-					return
-				}
-				saySubtone(ev.PID, "[ERROR] "+line)
-			}
-		}
-		if isBackground {
-			go runSubtoneWithEventsFn(args, onEvent)
-		} else {
-			exitCode := runSubtoneWithEventsFn(args, onEvent)
-			say(fmt.Sprintf("Subtone for %s exited with code %d.", cmdName, exitCode))
-		}
+		executeCommand(line, func(prefix, msg string) {
+			sayPrefixed(prefix, msg)
+		})
 	}
 	return scanner.Err()
 }
 
-func isTTY() bool {
-	fi, _ := os.Stdin.Stat()
+func isInputTTY(in io.Reader) bool {
+	stdin, ok := in.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := stdin.Stat()
+	if err != nil {
+		return false
+	}
 	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
-func printHelp(logFn func(category, msg string)) {
-	content := `Help
+func executeCommand(line string, emit func(prefix, msg string)) {
+	if emit == nil {
+		return
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
 
-### Bootstrap
-` + "`" + `dev install` + "`" + `
-Install latest Go and bootstrap dev.go command scaffold
-
-### Plugins
-` + "`" + `robot src_v1 install` + "`" + `
-Install robot src_v1 dependencies
-
-` + "`" + `dag src_v3 install` + "`" + `
-Install dag src_v3 dependencies
-
-` + "`" + `logs src_v1 test` + "`" + `
-Run logs plugin tests on a subtone
-
-### System
-` + "`" + `ps` + "`" + `
-List active subtones
-
-` + "`" + `kill <pid>` + "`" + `
-Kill a managed subtone process by PID
-
-` + "`" + `<any command>` + "`" + `
-Run any dialtone command on a managed subtone`
-
-	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		if i == 0 {
-			fmt.Println("DIALTONE> " + line)
-			logFn("REPL", "DIALTONE> "+line)
-		} else {
-			fmt.Println(line)
-			logFn("REPL", line)
+	if line == "help" {
+		printHelp(emit)
+		return
+	}
+	if line == "ps" {
+		printManagedProcesses(emit)
+		return
+	}
+	if strings.HasPrefix(line, "kill ") {
+		pidText := strings.TrimSpace(strings.TrimPrefix(line, "kill"))
+		pid := 0
+		if _, err := fmt.Sscanf(pidText, "%d", &pid); err != nil || pid <= 0 {
+			emit("DIALTONE", "Usage: kill <pid>")
+			return
 		}
+		if err := killManagedProcessFn(pid); err != nil {
+			emit("DIALTONE", fmt.Sprintf("Failed to kill process %d: %v", pid, err))
+		} else {
+			emit("DIALTONE", fmt.Sprintf("Killed managed process %d.", pid))
+		}
+		return
+	}
+
+	args := strings.Fields(line)
+	if len(args) == 0 {
+		return
+	}
+	cmdName := args[0]
+	if len(args) > 1 {
+		cmdName += " " + args[1]
+	}
+
+	isBackground := false
+	if args[len(args)-1] == "&" {
+		isBackground = true
+		args = args[:len(args)-1]
+		cmdName = strings.TrimSuffix(cmdName, " &")
+	}
+
+	emit("DIALTONE", fmt.Sprintf("Request received. Spawning subtone for %s...", cmdName))
+	onEvent := func(ev proc.SubtoneEvent) {
+		switch ev.Type {
+		case proc.SubtoneEventStarted:
+			if ev.PID <= 0 {
+				return
+			}
+			emit(fmt.Sprintf("DIALTONE:%d", ev.PID), fmt.Sprintf("Started at %s", ev.StartedAt.Format(time.RFC3339)))
+			emit(fmt.Sprintf("DIALTONE:%d", ev.PID), fmt.Sprintf("Command: %v", ev.Args))
+			if strings.TrimSpace(ev.LogPath) != "" {
+				emit(fmt.Sprintf("DIALTONE:%d", ev.PID), fmt.Sprintf("Log: %s", ev.LogPath))
+			}
+		case proc.SubtoneEventStdout:
+			if ev.PID <= 0 {
+				return
+			}
+			if hasStructuredLevel(ev.Line) {
+				emit(fmt.Sprintf("DIALTONE:%d", ev.PID), ev.Line)
+			}
+		case proc.SubtoneEventStderr:
+			if ev.PID <= 0 {
+				return
+			}
+			line := strings.TrimSpace(ev.Line)
+			if line == "" {
+				return
+			}
+			emit(fmt.Sprintf("DIALTONE:%d", ev.PID), "[ERROR] "+line)
+		case proc.SubtoneEventExited:
+			if ev.PID > 0 {
+				emit("DIALTONE", fmt.Sprintf("Subtone for %s exited with code %d.", cmdName, ev.ExitCode))
+			}
+		}
+	}
+
+	if isBackground {
+		go runSubtoneWithEventsFn(args, onEvent)
+		emit("DIALTONE", fmt.Sprintf("Subtone for %s started in background.", cmdName))
+		return
+	}
+	runSubtoneWithEventsFn(args, onEvent)
+}
+
+func printHelp(emit func(prefix, msg string)) {
+	content := []string{
+		"Help",
+		"",
+		"Bootstrap",
+		"`dev install`",
+		"Install latest Go and bootstrap dev.go command scaffold",
+		"",
+		"Plugins",
+		"`robot src_v1 install`",
+		"Install robot src_v1 dependencies",
+		"",
+		"`dag src_v3 install`",
+		"Install dag src_v3 dependencies",
+		"",
+		"`logs src_v1 test`",
+		"Run logs plugin tests on a subtone",
+		"",
+		"System",
+		"`ps`",
+		"List active subtones",
+		"",
+		"`kill <pid>`",
+		"Kill a managed subtone process by PID",
+		"",
+		"`<any command>`",
+		"Run any dialtone command on a managed subtone",
+	}
+	for _, line := range content {
+		emit("DIALTONE", line)
 	}
 }
 
-func printManagedProcesses(say func(msg string)) {
+func printManagedProcesses(emit func(prefix, msg string)) {
 	procs := listManagedFn()
 	if len(procs) == 0 {
-		say("No active subtones.")
+		emit("DIALTONE", "No active subtones.")
 		return
 	}
-	say("Active Subtones:")
-	say(fmt.Sprintf("%-8s %-8s %-10s %-8s %s", "PID", "UPTIME", "CPU%", "PORTS", "COMMAND"))
+	emit("DIALTONE", "Active Subtones:")
+	emit("DIALTONE", fmt.Sprintf("%-8s %-8s %-10s %-8s %s", "PID", "UPTIME", "CPU%", "PORTS", "COMMAND"))
 	for _, p := range procs {
-		say(fmt.Sprintf("%-8d %-8s %-10.1f %-8d %s", p.PID, p.StartedAgo, p.CPUPercent, p.PortCount, p.Command))
+		emit("DIALTONE", fmt.Sprintf("%-8d %-8s %-10.1f %-8d %s", p.PID, p.StartedAgo, p.CPUPercent, p.PortCount, p.Command))
 	}
 }
 
@@ -233,4 +555,130 @@ func hasStructuredLevel(line string) bool {
 		}
 	}
 	return false
+}
+
+func normalizePromptName(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, " ", "-")
+	if s == "" {
+		return "USER"
+	}
+	return s
+}
+
+func sanitizeRoom(room string) string {
+	room = strings.TrimSpace(room)
+	if room == "" {
+		return defaultRoom
+	}
+	room = strings.ReplaceAll(room, " ", "-")
+	return room
+}
+
+func replSubject(room string) string {
+	return "repl." + sanitizeRoom(room)
+}
+
+func connectNATS(natsURL string, embedded bool) (*nats.Conn, *logs.EmbeddedNATS, string, error) {
+	natsURL = strings.TrimSpace(natsURL)
+	if natsURL == "" {
+		natsURL = defaultNATSURL
+	}
+	if embedded {
+		broker, err := logs.StartEmbeddedNATSOnURL(natsURL)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		nc, err := nats.Connect(broker.URL(), nats.Timeout(1500*time.Millisecond))
+		if err != nil {
+			broker.Close()
+			return nil, nil, "", err
+		}
+		return nc, broker, broker.URL(), nil
+	}
+	nc, err := nats.Connect(natsURL, nats.Timeout(1500*time.Millisecond))
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return nc, nil, natsURL, nil
+}
+
+func publishFrame(nc *nats.Conn, subject string, frame BusFrame) error {
+	if nc == nil {
+		return fmt.Errorf("nil nats connection")
+	}
+	frame.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	payload, err := json.Marshal(frame)
+	if err != nil {
+		return err
+	}
+	return nc.Publish(subject, payload)
+}
+
+func decodeFrame(data []byte) (BusFrame, bool) {
+	var f BusFrame
+	if err := json.Unmarshal(data, &f); err != nil {
+		return BusFrame{}, false
+	}
+	f.Type = strings.TrimSpace(f.Type)
+	if f.Type == "" {
+		return BusFrame{}, false
+	}
+	return f, true
+}
+
+func printFrame(w io.Writer, frame BusFrame) {
+	switch frame.Type {
+	case frameTypeInput:
+		name := normalizePromptName(frame.From)
+		if name == "" {
+			name = "USER"
+		}
+		fmt.Fprintf(w, "%s> %s\n", name, strings.TrimSpace(frame.Message))
+	case frameTypeLine:
+		prefix := strings.TrimSpace(frame.Prefix)
+		if prefix == "" {
+			prefix = "DIALTONE"
+		}
+		fmt.Fprintf(w, "%s> %s\n", prefix, strings.TrimSpace(frame.Message))
+	case frameTypeServer:
+		fmt.Fprintf(w, "DIALTONE> %s\n", strings.TrimSpace(frame.Message))
+	case frameTypeJoin:
+		name := normalizePromptName(frame.From)
+		if name == "" {
+			name = normalizePromptName(frame.Message)
+		}
+		if name == "" {
+			name = "unknown"
+		}
+		fmt.Fprintf(w, "DIALTONE> [JOIN] %s\n", name)
+	case frameTypeLeft:
+		name := normalizePromptName(frame.From)
+		if name == "" {
+			name = normalizePromptName(frame.Message)
+		}
+		if name == "" {
+			name = "unknown"
+		}
+		fmt.Fprintf(w, "DIALTONE> [LEFT] %s\n", name)
+	}
+}
+
+func startTSNetInstance(hostname string) (func(), error) {
+	cfg, err := tsnetlib.ResolveConfig(hostname, "")
+	if err != nil {
+		return nil, err
+	}
+	srv := tsnetlib.BuildServer(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	status, err := srv.Up(ctx)
+	if err != nil {
+		_ = srv.Close()
+		return nil, err
+	}
+	logs.Info("REPL tsnet identity online: hostname=%s tailnet=%s ips=%v", status.Self.HostName, cfg.Tailnet, status.TailscaleIPs)
+	return func() {
+		_ = srv.Close()
+	}, nil
 }

--- a/src/plugins/repl/src_v1/go/repl/service.go
+++ b/src/plugins/repl/src_v1/go/repl/service.go
@@ -1,0 +1,589 @@
+package repl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	logs "dialtone/dev/plugins/logs/src_v1/go"
+)
+
+var BuildVersion = "dev"
+
+type releaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type releaseInfo struct {
+	TagName string         `json:"tag_name"`
+	Assets  []releaseAsset `json:"assets"`
+}
+
+type serviceManager struct {
+	mu      sync.Mutex
+	worker  *exec.Cmd
+	version string
+	path    string
+}
+
+type serviceOptions struct {
+	Mode           string
+	Repo           string
+	NATSURL        string
+	Room           string
+	CheckInterval  time.Duration
+	InstallDir     string
+	TokenEnv       string
+	EmbeddedNATS   bool
+	AllowDowngrade bool
+}
+
+func RunService(args []string) error {
+	fs := flag.NewFlagSet("repl-service", flag.ContinueOnError)
+	mode := fs.String("mode", "install", "Service mode: install|run|status")
+	repo := fs.String("repo", "timcash/dialtone", "GitHub repo owner/name")
+	natsURL := fs.String("nats-url", defaultNATSURL, "NATS URL for worker serve")
+	room := fs.String("room", defaultRoom, "REPL room for worker serve")
+	checkInterval := fs.Duration("check-interval", 3*time.Minute, "Update check interval")
+	installDir := fs.String("install-dir", filepath.Join(userHomeDir(), ".dialtone", "repl"), "Service install directory")
+	tokenEnv := fs.String("token-env", "GITHUB_TOKEN", "Token env var used for GitHub API")
+	embeddedNATS := fs.Bool("embedded-nats", true, "Pass --embedded-nats to worker")
+	allowDowngrade := fs.Bool("allow-downgrade", false, "Allow replacing worker with older version")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	opts := serviceOptions{
+		Mode:           strings.TrimSpace(*mode),
+		Repo:           strings.TrimSpace(*repo),
+		NATSURL:        strings.TrimSpace(*natsURL),
+		Room:           sanitizeRoom(*room),
+		CheckInterval:  *checkInterval,
+		InstallDir:     strings.TrimSpace(*installDir),
+		TokenEnv:       strings.TrimSpace(*tokenEnv),
+		EmbeddedNATS:   *embeddedNATS,
+		AllowDowngrade: *allowDowngrade,
+	}
+	if opts.Mode == "" {
+		opts.Mode = "install"
+	}
+
+	switch opts.Mode {
+	case "run":
+		return runServiceSupervisor(opts)
+	case "install":
+		return installService(opts)
+	case "status":
+		return serviceStatus(opts)
+	default:
+		return fmt.Errorf("unsupported service mode %q (expected install|run|status)", opts.Mode)
+	}
+}
+
+func runServiceSupervisor(opts serviceOptions) error {
+	if err := os.MkdirAll(opts.InstallDir, 0o755); err != nil {
+		return err
+	}
+
+	subdir := filepath.Join(opts.InstallDir, "releases")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		return err
+	}
+	currentLink := filepath.Join(opts.InstallDir, "current")
+	assetName := localAssetName()
+	token := strings.TrimSpace(os.Getenv(opts.TokenEnv))
+
+	rel, asset, err := latestRelease(opts.Repo, token, assetName)
+	if err != nil {
+		return fmt.Errorf("query latest release: %w", err)
+	}
+	if rel.TagName == "" {
+		return errors.New("latest release has empty tag")
+	}
+	workerPath, err := ensureReleaseBinary(opts.InstallDir, rel.TagName, assetName, asset.BrowserDownloadURL, token)
+	if err != nil {
+		return err
+	}
+	if err := switchCurrentLink(currentLink, workerPath); err != nil {
+		return err
+	}
+
+	mgr := &serviceManager{version: rel.TagName, path: workerPath}
+	if err := mgr.startWorker(currentLink, opts.NATSURL, opts.Room, opts.EmbeddedNATS); err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ticker := time.NewTicker(opts.CheckInterval)
+	defer ticker.Stop()
+
+	logs.Info("REPL service active: repo=%s room=%s nats=%s version=%s asset=%s", opts.Repo, opts.Room, opts.NATSURL, mgr.version, assetName)
+
+	for {
+		select {
+		case <-ctx.Done():
+			mgr.stopWorker(10 * time.Second)
+			return nil
+		case <-ticker.C:
+			latest, latestAsset, lerr := latestRelease(opts.Repo, token, assetName)
+			if lerr != nil {
+				logs.Warn("service update check failed: %v", lerr)
+				continue
+			}
+			if latest.TagName == "" {
+				continue
+			}
+			if !opts.AllowDowngrade && compareVersions(latest.TagName, mgr.version) <= 0 {
+				continue
+			}
+			newPath, derr := ensureReleaseBinary(opts.InstallDir, latest.TagName, assetName, latestAsset.BrowserDownloadURL, token)
+			if derr != nil {
+				logs.Warn("service download failed: %v", derr)
+				continue
+			}
+			logs.Info("service update: %s -> %s", mgr.version, latest.TagName)
+			mgr.stopWorker(10 * time.Second)
+			if lerr := switchCurrentLink(currentLink, newPath); lerr != nil {
+				logs.Error("switch current link failed: %v", lerr)
+				continue
+			}
+			mgr.version = latest.TagName
+			mgr.path = newPath
+			if serr := mgr.startWorker(currentLink, opts.NATSURL, opts.Room, opts.EmbeddedNATS); serr != nil {
+				logs.Error("restart updated worker failed: %v", serr)
+			}
+		}
+	}
+}
+
+func installService(opts serviceOptions) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	exe, _ = filepath.Abs(exe)
+	runArgs := serviceRunArgs(opts)
+
+	switch runtime.GOOS {
+	case "linux":
+		return installSystemdUserService(exe, runArgs)
+	case "darwin":
+		return installLaunchdUserService(exe, runArgs)
+	default:
+		return fmt.Errorf("service install unsupported on %s", runtime.GOOS)
+	}
+}
+
+func serviceStatus(opts serviceOptions) error {
+	switch runtime.GOOS {
+	case "linux":
+		cmd := exec.Command("systemctl", "--user", "status", "--no-pager", "repl-src_v1.service")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	case "darwin":
+		uid := os.Getuid()
+		label := "dev.dialtone.repl-src_v1"
+		cmd := exec.Command("launchctl", "print", fmt.Sprintf("gui/%d/%s", uid, label))
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	default:
+		return fmt.Errorf("service status unsupported on %s", runtime.GOOS)
+	}
+}
+
+func serviceRunArgs(opts serviceOptions) []string {
+	args := []string{
+		"service", "--mode", "run",
+		"--repo", opts.Repo,
+		"--nats-url", opts.NATSURL,
+		"--room", opts.Room,
+		"--check-interval", opts.CheckInterval.String(),
+		"--install-dir", opts.InstallDir,
+		"--token-env", opts.TokenEnv,
+	}
+	if opts.EmbeddedNATS {
+		args = append(args, "--embedded-nats")
+	} else {
+		args = append(args, "--embedded-nats=false")
+	}
+	if opts.AllowDowngrade {
+		args = append(args, "--allow-downgrade")
+	}
+	return args
+}
+
+func installSystemdUserService(exe string, runArgs []string) error {
+	home := userHomeDir()
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	if err := os.MkdirAll(unitDir, 0o755); err != nil {
+		return err
+	}
+	unitPath := filepath.Join(unitDir, "repl-src_v1.service")
+	logPath := filepath.Join(home, ".dialtone", "logs", "repl-service.log")
+	_ = os.MkdirAll(filepath.Dir(logPath), 0o755)
+
+	execStart := exe + " " + strings.Join(runArgs, " ")
+	unit := strings.Join([]string{
+		"[Unit]",
+		"Description=Dialtone REPL Service Supervisor",
+		"After=default.target network-online.target",
+		"",
+		"[Service]",
+		"Type=simple",
+		"ExecStart=" + execStart,
+		"Restart=always",
+		"RestartSec=2",
+		"StandardOutput=append:" + logPath,
+		"StandardError=append:" + logPath,
+		"",
+		"[Install]",
+		"WantedBy=default.target",
+		"",
+	}, "\n")
+	if err := os.WriteFile(unitPath, []byte(unit), 0o644); err != nil {
+		return err
+	}
+	for _, args := range [][]string{
+		{"--user", "daemon-reload"},
+		{"--user", "enable", "--now", "repl-src_v1.service"},
+	} {
+		cmd := exec.Command("systemctl", args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	logs.Info("Installed systemd user service: %s", unitPath)
+	return nil
+}
+
+func installLaunchdUserService(exe string, runArgs []string) error {
+	home := userHomeDir()
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(plistDir, 0o755); err != nil {
+		return err
+	}
+	label := "dev.dialtone.repl-src_v1"
+	plistPath := filepath.Join(plistDir, label+".plist")
+	logPath := filepath.Join(home, "Library", "Logs", "dialtone-repl-service.log")
+
+	argsXML := "<string>" + xmlEscape(exe) + "</string>\n"
+	for _, a := range runArgs {
+		argsXML += "\t\t<string>" + xmlEscape(a) + "</string>\n"
+	}
+
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>` + label + `</string>
+	<key>ProgramArguments</key>
+	<array>
+		` + strings.TrimSpace(argsXML) + `
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>` + xmlEscape(logPath) + `</string>
+	<key>StandardErrorPath</key>
+	<string>` + xmlEscape(logPath) + `</string>
+</dict>
+</plist>
+`
+	if err := os.WriteFile(plistPath, []byte(plist), 0o644); err != nil {
+		return err
+	}
+
+	uid := os.Getuid()
+	_ = exec.Command("launchctl", "bootout", fmt.Sprintf("gui/%d/%s", uid, label)).Run()
+	for _, args := range [][]string{
+		{"bootstrap", fmt.Sprintf("gui/%d", uid), plistPath},
+		{"enable", fmt.Sprintf("gui/%d/%s", uid, label)},
+		{"kickstart", "-k", fmt.Sprintf("gui/%d/%s", uid, label)},
+	} {
+		cmd := exec.Command("launchctl", args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	logs.Info("Installed launchd user service: %s", plistPath)
+	return nil
+}
+
+func xmlEscape(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		"\"", "&quot;",
+		"'", "&apos;",
+	)
+	return r.Replace(s)
+}
+
+func (m *serviceManager) startWorker(currentPath, natsURL, room string, embeddedNATS bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.worker != nil && m.worker.Process != nil {
+		return nil
+	}
+	args := []string{"serve", "--nats-url", natsURL, "--room", room}
+	if embeddedNATS {
+		args = append(args, "--embedded-nats")
+	}
+	cmd := exec.Command(currentPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = nil
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	m.worker = cmd
+	logs.Info("service started repl worker pid=%d version=%s", cmd.Process.Pid, m.version)
+	go func(local *exec.Cmd, version string) {
+		err := local.Wait()
+		if err != nil {
+			logs.Warn("worker exited version=%s: %v", version, err)
+		} else {
+			logs.Warn("worker exited version=%s", version)
+		}
+		m.mu.Lock()
+		if m.worker == local {
+			m.worker = nil
+		}
+		m.mu.Unlock()
+	}(cmd, m.version)
+	return nil
+}
+
+func (m *serviceManager) stopWorker(timeout time.Duration) {
+	m.mu.Lock()
+	cmd := m.worker
+	m.mu.Unlock()
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		_ = cmd.Process.Kill()
+	}
+	m.mu.Lock()
+	if m.worker == cmd {
+		m.worker = nil
+	}
+	m.mu.Unlock()
+}
+
+func ensureReleaseBinary(installDir, tag, assetName, downloadURL, token string) (string, error) {
+	dstDir := filepath.Join(installDir, "releases", sanitizeTag(tag))
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return "", err
+	}
+	dstPath := filepath.Join(dstDir, assetName)
+	if _, err := os.Stat(dstPath); err == nil {
+		return dstPath, nil
+	}
+	if strings.TrimSpace(downloadURL) == "" {
+		return "", fmt.Errorf("release asset %s has empty download URL", assetName)
+	}
+	if err := downloadFile(downloadURL, token, dstPath+".tmp"); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(dstPath+".tmp", 0o755); err != nil {
+		return "", err
+	}
+	if err := os.Rename(dstPath+".tmp", dstPath); err != nil {
+		return "", err
+	}
+	return dstPath, nil
+}
+
+func downloadFile(url, token, outPath string) error {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("download failed: %s %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func latestRelease(repo, token, assetName string) (releaseInfo, releaseAsset, error) {
+	url := "https://api.github.com/repos/" + strings.TrimSpace(repo) + "/releases/latest"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return releaseInfo{}, releaseAsset{}, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return releaseInfo{}, releaseAsset{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return releaseInfo{}, releaseAsset{}, fmt.Errorf("github latest release failed: %s %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var rel releaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return releaseInfo{}, releaseAsset{}, err
+	}
+	for _, a := range rel.Assets {
+		if a.Name == assetName {
+			return rel, a, nil
+		}
+	}
+	assetNames := make([]string, 0, len(rel.Assets))
+	for _, a := range rel.Assets {
+		assetNames = append(assetNames, a.Name)
+	}
+	sort.Strings(assetNames)
+	return rel, releaseAsset{}, fmt.Errorf("asset %s not found in release %s (assets=%v)", assetName, rel.TagName, assetNames)
+}
+
+func localAssetName() string {
+	name := fmt.Sprintf("repl-src_v1-%s-%s", runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+func compareVersions(a, b string) int {
+	aa := parseVersionParts(a)
+	bb := parseVersionParts(b)
+	for i := 0; i < len(aa) || i < len(bb); i++ {
+		av, bv := 0, 0
+		if i < len(aa) {
+			av = aa[i]
+		}
+		if i < len(bb) {
+			bv = bb[i]
+		}
+		if av > bv {
+			return 1
+		}
+		if av < bv {
+			return -1
+		}
+	}
+	return 0
+}
+
+func parseVersionParts(v string) []int {
+	v = strings.TrimSpace(strings.TrimPrefix(v, "v"))
+	segments := strings.Split(v, ".")
+	parts := make([]int, 0, len(segments))
+	for _, s := range segments {
+		n := strings.Builder{}
+		for _, r := range s {
+			if r >= '0' && r <= '9' {
+				n.WriteRune(r)
+			} else {
+				break
+			}
+		}
+		if n.Len() == 0 {
+			parts = append(parts, 0)
+			continue
+		}
+		iv, err := strconv.Atoi(n.String())
+		if err != nil {
+			parts = append(parts, 0)
+			continue
+		}
+		parts = append(parts, iv)
+	}
+	return parts
+}
+
+func sanitizeTag(tag string) string {
+	tag = strings.TrimSpace(tag)
+	tag = strings.ReplaceAll(tag, "/", "-")
+	tag = strings.ReplaceAll(tag, "\\", "-")
+	if tag == "" {
+		return "unknown"
+	}
+	return tag
+}
+
+func userHomeDir() string {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	return h
+}
+
+func switchCurrentLink(currentLink, target string) error {
+	_ = os.Remove(currentLink)
+	if err := os.Symlink(target, currentLink); err == nil {
+		return nil
+	}
+	// Symlink fallback for platforms/filesystems without symlink support.
+	in, err := os.Open(target)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(currentLink)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return os.Chmod(currentLink, 0o755)
+}

--- a/src/plugins/repl/src_v1/test/01_repl_core/suite.go
+++ b/src/plugins/repl/src_v1/test/01_repl_core/suite.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
 	support "dialtone/dev/plugins/repl/src_v1/test/support"
 	testv1 "dialtone/dev/plugins/test/src_v1/go"
 )
@@ -13,6 +14,7 @@ func Register(r *testv1.Registry) {
 	r.Add(testv1.Step{
 		Name: "repl-help-and-format",
 		RunWithContext: func(ctx *testv1.StepContext) (testv1.StepRunResult, error) {
+			prompt := repl.DefaultPromptName()
 			out, relayed, err := support.RunSessionWithInput(ctx, "help\nexit\n")
 			if err != nil {
 				return testv1.StepRunResult{}, err
@@ -21,7 +23,7 @@ func Register(r *testv1.Registry) {
 			if err := support.RequireContainsAll(out, []string{
 				"DIALTONE> Virtual Librarian online.",
 				"DIALTONE> Type 'help' for commands, or 'exit' to quit.",
-				"USER-1> help",
+				fmt.Sprintf("%s> help", prompt),
 				"DIALTONE> Help",
 				"`dev install`",
 				"`robot src_v1 install`",
@@ -43,8 +45,8 @@ func Register(r *testv1.Registry) {
 			if !support.ContainsAny(relayed, "DIALTONE> Help") {
 				return testv1.StepRunResult{}, fmt.Errorf("expected help output in REPL relay log")
 			}
-			if !support.ContainsAny(relayed, "USER-1> help") {
-				return testv1.StepRunResult{}, fmt.Errorf("expected USER-1 input in REPL relay log")
+			if !support.ContainsAny(relayed, fmt.Sprintf("%s> help", prompt)) {
+				return testv1.StepRunResult{}, fmt.Errorf("expected prompt input in REPL relay log")
 			}
 
 			if err := ctx.WaitForStepMessageAfterAction("repl-core-help-format-ok", 3*time.Second, func() error {

--- a/src/plugins/repl/src_v1/test/02_proc_plugin/suite.go
+++ b/src/plugins/repl/src_v1/test/02_proc_plugin/suite.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
 	support "dialtone/dev/plugins/repl/src_v1/test/support"
 	testv1 "dialtone/dev/plugins/test/src_v1/go"
 )
@@ -13,12 +14,13 @@ func Register(r *testv1.Registry) {
 		Name:    "repl-runs-proc-test-subtone",
 		Timeout: 90 * time.Second,
 		RunWithContext: func(ctx *testv1.StepContext) (testv1.StepRunResult, error) {
+			prompt := repl.DefaultPromptName()
 			out, _, err := support.RunSessionWithInput(ctx, "proc src_v1 test\nexit\n")
 			if err != nil {
 				return testv1.StepRunResult{}, err
 			}
 			if err := support.RequireContainsAll(out, []string{
-				"USER-1> proc src_v1 test",
+				prompt + "> proc src_v1 test",
 				"DIALTONE> Request received. Spawning subtone for proc src_v1...",
 				"DIALTONE> Subtone for proc src_v1 exited with code 0.",
 			}); err != nil {

--- a/src/plugins/repl/src_v1/test/03_logs_plugin/suite.go
+++ b/src/plugins/repl/src_v1/test/03_logs_plugin/suite.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
 	support "dialtone/dev/plugins/repl/src_v1/test/support"
 	testv1 "dialtone/dev/plugins/test/src_v1/go"
 )
@@ -13,12 +14,13 @@ func Register(r *testv1.Registry) {
 		Name:    "repl-runs-logs-test-subtone",
 		Timeout: 120 * time.Second,
 		RunWithContext: func(ctx *testv1.StepContext) (testv1.StepRunResult, error) {
+			prompt := repl.DefaultPromptName()
 			out, _, err := support.RunSessionWithInput(ctx, "logs src_v1 test\nexit\n")
 			if err != nil {
 				return testv1.StepRunResult{}, err
 			}
 			if err := support.RequireContainsAll(out, []string{
-				"USER-1> logs src_v1 test",
+				prompt + "> logs src_v1 test",
 				"DIALTONE> Request received. Spawning subtone for logs src_v1...",
 				"DIALTONE> Subtone for logs src_v1 exited with code 0.",
 			}); err != nil {

--- a/src/plugins/repl/src_v1/test/04_test_plugin/suite.go
+++ b/src/plugins/repl/src_v1/test/04_test_plugin/suite.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
 	support "dialtone/dev/plugins/repl/src_v1/test/support"
 	testv1 "dialtone/dev/plugins/test/src_v1/go"
 )
@@ -13,12 +14,13 @@ func Register(r *testv1.Registry) {
 		Name:    "repl-runs-test-plugin-subtone",
 		Timeout: 150 * time.Second,
 		RunWithContext: func(ctx *testv1.StepContext) (testv1.StepRunResult, error) {
+			prompt := repl.DefaultPromptName()
 			out, _, err := support.RunSessionWithInput(ctx, "test src_v1 test\nexit\n")
 			if err != nil {
 				return testv1.StepRunResult{}, err
 			}
 			if err := support.RequireContainsAll(out, []string{
-				"USER-1> test src_v1 test",
+				prompt + "> test src_v1 test",
 				"DIALTONE> Request received. Spawning subtone for test src_v1...",
 				"DIALTONE> Subtone for test src_v1 exited with code 0.",
 			}); err != nil {

--- a/src/plugins/repl/src_v1/test/05_chrome_plugin/suite.go
+++ b/src/plugins/repl/src_v1/test/05_chrome_plugin/suite.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
 	support "dialtone/dev/plugins/repl/src_v1/test/support"
 	testv1 "dialtone/dev/plugins/test/src_v1/go"
 )
@@ -13,12 +14,13 @@ func Register(r *testv1.Registry) {
 		Name:    "repl-runs-chrome-foundation-command",
 		Timeout: 60 * time.Second,
 		RunWithContext: func(ctx *testv1.StepContext) (testv1.StepRunResult, error) {
+			prompt := repl.DefaultPromptName()
 			out, _, err := support.RunSessionWithInput(ctx, "chrome src_v1 list\nexit\n")
 			if err != nil {
 				return testv1.StepRunResult{}, err
 			}
 			if err := support.RequireContainsAll(out, []string{
-				"USER-1> chrome src_v1 list",
+				prompt + "> chrome src_v1 list",
 				"DIALTONE> Request received. Spawning subtone for chrome src_v1...",
 				"DIALTONE> Subtone for chrome src_v1 exited with code 0.",
 			}); err != nil {

--- a/src/plugins/repl/src_v1/test/06_go_bun_plugins/suite.go
+++ b/src/plugins/repl/src_v1/test/06_go_bun_plugins/suite.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
 	support "dialtone/dev/plugins/repl/src_v1/test/support"
 	testv1 "dialtone/dev/plugins/test/src_v1/go"
 )
@@ -14,6 +15,7 @@ func Register(r *testv1.Registry) {
 		Name:    "repl-runs-go-and-bun-tests-bottom-up",
 		Timeout: 180 * time.Second,
 		RunWithContext: func(ctx *testv1.StepContext) (testv1.StepRunResult, error) {
+			prompt := repl.DefaultPromptName()
 			input := strings.Join([]string{
 				"go src_v1 test",
 				"bun src_v1 test",
@@ -25,10 +27,10 @@ func Register(r *testv1.Registry) {
 				return testv1.StepRunResult{}, err
 			}
 			if err := support.RequireContainsAll(out, []string{
-				"USER-1> go src_v1 test",
+				prompt + "> go src_v1 test",
 				"DIALTONE> Request received. Spawning subtone for go src_v1...",
 				"DIALTONE> Subtone for go src_v1 exited with code 0.",
-				"USER-1> bun src_v1 test",
+				prompt + "> bun src_v1 test",
 				"DIALTONE> Request received. Spawning subtone for bun src_v1...",
 				"DIALTONE> Subtone for bun src_v1 exited with code 0.",
 			}); err != nil {


### PR DESCRIPTION
## Summary
- add REPL service supervisor with auto-update from GitHub Releases
- add `service --mode install|run|status` and make `install` default
- install persistent service targets:
  - systemd user unit on Linux
  - launchd user agent on macOS
- move REPL room traffic to a single `repl.<room>` NATS subject model
- ensure input/output flows over NATS first, with server listening on the room subject
- add `[JOIN]` and `[LEFT]` membership events in REPL output
- add `github release upsert` command and route `repl release publish` through github plugin
- add release build/publish CLI for per-arch artifacts

## Validation
- go test for repl/github packages
- `./dialtone.sh repl src_v1 test`
- live 3-host REPL verification over tailscale
- live supervisor hot-swap verification from one release to the next
- verified persistent service registration/run on legion, darkmac, and chroma
