### PR TITLE
repl: add who/versions commands with version visibility

### DIFF
--- a/src/plugins/repl/README.md
+++ b/src/plugins/repl/README.md
@@ -23,6 +23,8 @@ Prompts default to host identity (`<hostname>`) instead of `USER-1`.
 ./dialtone.sh repl src_v1 release build v0.1.0
 ./dialtone.sh repl src_v1 release publish v0.1.0 timcash/dialtone
 ./dialtone.sh repl src_v1 test
+./dialtone.sh repl src_v1 test multiplayer
+./dialtone.sh repl src_v1 test multiplayer-robot
 ```
 
 ## Interactive Commands
@@ -30,6 +32,8 @@ When running `run`, `leader`, or `join`, the REPL session supports internal mana
 - `/ps`: List active subtones (background processes)
 - `/kill <pid>`: Terminate a managed process
 - `/repl src_v1 join <room-name>`: Leave current room and join another room
+- `/repl src_v1 who`: List connected users, room, and REPL version
+- `/repl src_v1 versions`: List connected users with REPL version by room
 - `/<command>` or `/plugin src_vN command ...`: Send command to DIALTONE leader
 - `exit` / `quit`: Close the session
 
@@ -124,3 +128,9 @@ This is the **REPL Auto-Swap Updater** path.
 - `src/plugins/repl/src_v1/test/04_test_plugin/suite.go`
 - `src/plugins/repl/src_v1/test/05_chrome_plugin/suite.go`
 - `src/plugins/repl/src_v1/test/06_go_bun_plugins/suite.go`
+- `src/plugins/repl/src_v1/test/99_multiplayer/suite.go`
+- `src/plugins/repl/src_v1/test/100_multiplayer_robot/suite.go`
+
+Extra modes:
+- `repl src_v1 test multiplayer`: runs only NATS-driven multiplayer suite.
+- `repl src_v1 test multiplayer-robot`: runs multiplayer + live robot SSH join/chat/left verification.

--- a/src/plugins/repl/src_v1/go/repl/repl.go
+++ b/src/plugins/repl/src_v1/go/repl/repl.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -86,6 +87,7 @@ type BusFrame struct {
 	From      string   `json:"from,omitempty"`
 	Target    string   `json:"target,omitempty"`
 	Room      string   `json:"room,omitempty"`
+	Version   string   `json:"version,omitempty"`
 	Command   string   `json:"command,omitempty"`
 	Args      []string `json:"args,omitempty"`
 	Prefix    string   `json:"prefix,omitempty"`
@@ -207,6 +209,59 @@ func RunLeader(args []string) error {
 
 	var roomMu sync.RWMutex
 	userRoom := map[string]string{}
+	type userPresence struct {
+		Room    string
+		Version string
+	}
+	var presenceMu sync.RWMutex
+	presence := map[string]userPresence{}
+	upsertPresence := func(user, room, version string) {
+		user = normalizePromptName(user)
+		if user == "" {
+			return
+		}
+		room = sanitizeRoom(room)
+		presenceMu.Lock()
+		prev := presence[user]
+		if strings.TrimSpace(version) == "" {
+			version = prev.Version
+		}
+		presence[user] = userPresence{Room: room, Version: strings.TrimSpace(version)}
+		presenceMu.Unlock()
+	}
+	removePresence := func(user string) {
+		user = normalizePromptName(user)
+		if user == "" {
+			return
+		}
+		presenceMu.Lock()
+		delete(presence, user)
+		presenceMu.Unlock()
+	}
+	listPresence := func() []struct {
+		Name    string
+		Room    string
+		Version string
+	} {
+		presenceMu.RLock()
+		rows := make([]struct {
+			Name    string
+			Room    string
+			Version string
+		}, 0, len(presence))
+		for k, v := range presence {
+			rows = append(rows, struct {
+				Name    string
+				Room    string
+				Version string
+			}{Name: k, Room: sanitizeRoom(v.Room), Version: strings.TrimSpace(v.Version)})
+		}
+		presenceMu.RUnlock()
+		sort.Slice(rows, func(i, j int) bool {
+			return rows[i].Name < rows[j].Name
+		})
+		return rows
+	}
 	var runMu sync.Mutex
 	cmdSub, err := nc.QueueSubscribe(commandSubject, commandQueue, func(msg *nats.Msg) {
 		frame, ok := decodeFrame(msg.Data)
@@ -244,12 +299,54 @@ func RunLeader(args []string) error {
 			roomMu.Lock()
 			userRoom[sender] = currentRoom
 			roomMu.Unlock()
+			upsertPresence(sender, currentRoom, frame.Version)
 			publishRoom(currentRoom, BusFrame{Type: frameTypeInput, From: sender, Message: "/" + raw})
+
+			if len(args) >= 3 && args[0] == "repl" && args[1] == "src_v1" && args[2] == "who" {
+				rows := listPresence()
+				if len(rows) == 0 {
+					publishRoom(currentRoom, BusFrame{Type: frameTypeLine, Prefix: "DIALTONE", Message: "No connected users."})
+					return
+				}
+				publishRoom(currentRoom, BusFrame{Type: frameTypeLine, Prefix: "DIALTONE", Message: "Connected users:"})
+				for _, row := range rows {
+					version := row.Version
+					if version == "" {
+						version = "unknown"
+					}
+					publishRoom(currentRoom, BusFrame{
+						Type:    frameTypeLine,
+						Prefix:  "DIALTONE",
+						Message: fmt.Sprintf("- %s (room=%s version=%s)", row.Name, sanitizeRoom(row.Room), version),
+					})
+				}
+				return
+			}
+			if len(args) >= 3 && args[0] == "repl" && args[1] == "src_v1" && args[2] == "versions" {
+				rows := listPresence()
+				if len(rows) == 0 {
+					publishRoom(currentRoom, BusFrame{Type: frameTypeLine, Prefix: "DIALTONE", Message: "No connected users."})
+					return
+				}
+				publishRoom(currentRoom, BusFrame{Type: frameTypeLine, Prefix: "DIALTONE", Message: "Connected REPL versions:"})
+				for _, row := range rows {
+					version := row.Version
+					if version == "" {
+						version = "unknown"
+					}
+					publishRoom(currentRoom, BusFrame{
+						Type:    frameTypeLine,
+						Prefix:  "DIALTONE",
+						Message: fmt.Sprintf("- %s version=%s room=%s", row.Name, version, sanitizeRoom(row.Room)),
+					})
+				}
+				return
+			}
 
 			if len(args) >= 4 && args[0] == "repl" && args[1] == "src_v1" && args[2] == "join" {
 				targetRoom := sanitizeRoom(args[3])
 				if targetRoom == "" {
-					publishRoom(currentRoom, BusFrame{Type: frameTypeError, Message: "Usage: /repl src_v1 join <room-name>"})
+					publishRoom(currentRoom, BusFrame{Type: frameTypeError, Message: "Usage: /repl src_v1 join <room-name> | /repl src_v1 who | /repl src_v1 versions"})
 					return
 				}
 				if targetRoom == currentRoom {
@@ -288,6 +385,12 @@ func RunLeader(args []string) error {
 		frame, ok := decodeFrame(msg.Data)
 		if !ok {
 			return
+		}
+		switch frame.Type {
+		case frameTypeJoin:
+			upsertPresence(frame.From, frame.Room, frame.Version)
+		case frameTypeLeft:
+			removePresence(frame.From)
 		}
 		printFrame(os.Stdout, frame)
 	})
@@ -447,7 +550,7 @@ func RunJoin(args []string) error {
 	}
 
 	_ = publishFrame(nc, commandSubject, BusFrame{Type: frameTypeProbe, From: prompt, Room: currentRoom, Message: "probe"})
-	_ = publishFrame(nc, currentSubj, BusFrame{Type: frameTypeJoin, From: prompt, Room: currentRoom})
+	_ = publishFrame(nc, currentSubj, BusFrame{Type: frameTypeJoin, From: prompt, Room: currentRoom, Version: BuildVersion})
 	_ = nc.Flush()
 	writeLine(fmt.Sprintf("DIALTONE> Connected to %s via %s", currentSubj, natsAddr))
 
@@ -476,6 +579,7 @@ func RunJoin(args []string) error {
 				Type:    frameTypeCommand,
 				From:    prompt,
 				Room:    roomNow,
+				Version: BuildVersion,
 				Message: line,
 			}); err != nil {
 				return err
@@ -900,7 +1004,11 @@ func printFrame(w io.Writer, frame BusFrame) {
 		if strings.TrimSpace(frame.Room) == "" {
 			fmt.Fprintf(w, "DIALTONE> [JOIN] %s\n", name)
 		} else {
-			fmt.Fprintf(w, "DIALTONE> [JOIN] %s (room=%s)\n", name, sanitizeRoom(frame.Room))
+			if strings.TrimSpace(frame.Version) == "" {
+				fmt.Fprintf(w, "DIALTONE> [JOIN] %s (room=%s)\n", name, sanitizeRoom(frame.Room))
+			} else {
+				fmt.Fprintf(w, "DIALTONE> [JOIN] %s (room=%s version=%s)\n", name, sanitizeRoom(frame.Room), strings.TrimSpace(frame.Version))
+			}
 		}
 	case frameTypeLeft:
 		name := normalizePromptName(frame.From)

--- a/src/plugins/repl/src_v1/test/100_multiplayer_robot/suite.go
+++ b/src/plugins/repl/src_v1/test/100_multiplayer_robot/suite.go
@@ -1,0 +1,214 @@
+package multiplayerrobot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	repl "dialtone/dev/plugins/repl/src_v1/go/repl"
+	testv1 "dialtone/dev/plugins/test/src_v1/go"
+	"github.com/nats-io/nats.go"
+)
+
+type observedFrame struct {
+	Subject string
+	Frame   repl.BusFrame
+}
+
+func Register(r *testv1.Registry) {
+	r.Add(testv1.Step{
+		Name:    "repl-multiplayer-live-with-robot-over-ssh",
+		Timeout: 120 * time.Second,
+		RunWithContext: func(ctx *testv1.StepContext) (testv1.StepRunResult, error) {
+			robotHost := strings.TrimSpace(os.Getenv("ROBOT_HOST"))
+			robotUser := strings.TrimSpace(os.Getenv("ROBOT_USER"))
+			robotPass := os.Getenv("ROBOT_PASSWORD")
+			if robotHost == "" || robotUser == "" || strings.TrimSpace(robotPass) == "" {
+				return testv1.StepRunResult{
+					Report: "skipped live robot multiplayer test (ROBOT_HOST/ROBOT_USER/ROBOT_PASSWORD not set)",
+				}, nil
+			}
+			if _, err := exec.LookPath("sshpass"); err != nil {
+				return testv1.StepRunResult{
+					Report: "skipped live robot multiplayer test (sshpass unavailable)",
+				}, nil
+			}
+
+			paths, err := repl.ResolvePaths("")
+			if err != nil {
+				return testv1.StepRunResult{}, err
+			}
+			dialtoneBin := filepath.Join(paths.Runtime.RepoRoot, "dialtone.sh")
+			natsURL := strings.TrimSpace(ctx.NATSURL())
+			if natsURL == "" {
+				natsURL = "nats://127.0.0.1:4222"
+			}
+			robotNATSURL, err := rewriteNATSURLForRobot(natsURL, robotHost)
+			if err != nil {
+				return testv1.StepRunResult{}, err
+			}
+
+			nc := ctx.NATSConn()
+			if nc == nil {
+				return testv1.StepRunResult{}, fmt.Errorf("NATS connection unavailable in test context")
+			}
+
+			var (
+				obsMu sync.Mutex
+				obs   []observedFrame
+			)
+			sub, err := nc.Subscribe("repl.>", func(msg *nats.Msg) {
+				var frame repl.BusFrame
+				if json.Unmarshal(msg.Data, &frame) != nil {
+					return
+				}
+				obsMu.Lock()
+				obs = append(obs, observedFrame{Subject: msg.Subject, Frame: frame})
+				obsMu.Unlock()
+			})
+			if err != nil {
+				return testv1.StepRunResult{}, err
+			}
+			defer sub.Unsubscribe()
+			_ = nc.Flush()
+
+			leaderCtx, cancelLeader := context.WithCancel(context.Background())
+			defer cancelLeader()
+			leaderCmd := exec.CommandContext(
+				leaderCtx,
+				dialtoneBin,
+				"repl", "src_v1", "leader",
+				"--embedded-nats=false",
+				"--nats-url", natsURL,
+				"--room", "index",
+				"--hostname", "DIALTONE-SERVER",
+			)
+			leaderCmd.Dir = paths.Runtime.RepoRoot
+			if err := leaderCmd.Start(); err != nil {
+				return testv1.StepRunResult{}, err
+			}
+			defer func() {
+				cancelLeader()
+				if leaderCmd.Process != nil {
+					_ = leaderCmd.Process.Kill()
+				}
+			}()
+
+			if err := waitFor(12*time.Second, func() bool {
+				return hasFrame(&obsMu, &obs, func(of observedFrame) bool {
+					return of.Subject == "repl.room.index" && of.Frame.Type == "server"
+				})
+			}); err != nil {
+				return testv1.StepRunResult{}, fmt.Errorf("leader did not publish ready frame: %w", err)
+			}
+
+			remoteRepo := strings.TrimSpace(os.Getenv("ROBOT_REPL_REPO"))
+			if remoteRepo == "" {
+				remoteRepo = "/home/" + robotUser + "/dialtone"
+			}
+			remoteScript := fmt.Sprintf(
+				"set -e; cd %s; printf 'hello-from-robot\\n/quit\\n' | ./dialtone.sh repl src_v1 join --nats-url %s --name robot-client --room index",
+				shellQuote(remoteRepo),
+				shellQuote(robotNATSURL),
+			)
+			sshTarget := fmt.Sprintf("%s@%s", robotUser, robotHost)
+			sshCmd := exec.Command(
+				"sshpass", "-p", robotPass,
+				"ssh", "-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=12",
+				sshTarget,
+				remoteScript,
+			)
+			sshOut, sshErr := sshCmd.CombinedOutput()
+			if sshErr != nil {
+				return testv1.StepRunResult{}, fmt.Errorf("robot join command failed: %w\n%s", sshErr, strings.TrimSpace(string(sshOut)))
+			}
+
+			if err := waitFor(15*time.Second, func() bool {
+				joined := hasFrame(&obsMu, &obs, func(of observedFrame) bool {
+					return of.Subject == "repl.room.index" && of.Frame.Type == "join" && of.Frame.From == "robot-client"
+				})
+				chatted := hasFrame(&obsMu, &obs, func(of observedFrame) bool {
+					return of.Subject == "repl.room.index" && of.Frame.Type == "chat" && of.Frame.From == "robot-client" && strings.Contains(of.Frame.Message, "hello-from-robot")
+				})
+				left := hasFrame(&obsMu, &obs, func(of observedFrame) bool {
+					return of.Subject == "repl.room.index" && of.Frame.Type == "left" && of.Frame.From == "robot-client"
+				})
+				return joined && chatted && left
+			}); err != nil {
+				return testv1.StepRunResult{}, fmt.Errorf("robot join/chat/left frames not fully observed: %w", err)
+			}
+
+			return testv1.StepRunResult{
+				Report: fmt.Sprintf("live multiplayer verified with robot client over SSH (nats=%s)", robotNATSURL),
+			}, nil
+		},
+	})
+}
+
+func waitFor(timeout time.Duration, condition func() bool) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return nil
+		}
+		time.Sleep(120 * time.Millisecond)
+	}
+	return fmt.Errorf("condition not satisfied within %s", timeout)
+}
+
+func hasFrame(mu *sync.Mutex, frames *[]observedFrame, predicate func(observedFrame) bool) bool {
+	mu.Lock()
+	defer mu.Unlock()
+	for _, f := range *frames {
+		if predicate(f) {
+			return true
+		}
+	}
+	return false
+}
+
+func rewriteNATSURLForRobot(natsURL, robotHost string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(natsURL))
+	if err != nil {
+		return "", fmt.Errorf("invalid NATS URL %q: %w", natsURL, err)
+	}
+	host := u.Hostname()
+	if host != "127.0.0.1" && host != "localhost" {
+		return u.String(), nil
+	}
+	port := u.Port()
+	if port == "" {
+		port = "4222"
+	}
+	localIP, err := outboundIPFor(robotHost)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve local IP for robot route: %w", err)
+	}
+	u.Host = net.JoinHostPort(localIP, port)
+	return u.String(), nil
+}
+
+func outboundIPFor(remoteHost string) (string, error) {
+	conn, err := net.DialTimeout("udp", net.JoinHostPort(remoteHost, "9"), 3*time.Second)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || addr.IP == nil {
+		return "", fmt.Errorf("unexpected local address type")
+	}
+	return addr.IP.String(), nil
+}
+
+func shellQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", "'\"'\"'") + "'"
+}

--- a/src/plugins/repl/src_v1/test/99_multiplayer/suite.go
+++ b/src/plugins/repl/src_v1/test/99_multiplayer/suite.go
@@ -128,6 +128,31 @@ func Register(r *testv1.Registry) {
 			}); err != nil {
 				return testv1.StepRunResult{}, fmt.Errorf("expected three join events: %w\n%s", err, snapshotFrames(&obsMu, &obs, 60))
 			}
+			stage.Store("command-who-versions")
+			if err := publish(nc, "repl.cmd", repl.BusFrame{Type: "command", From: "user-1", Room: "index", Version: "v1.2.3", Message: "/repl src_v1 who"}); err != nil {
+				return testv1.StepRunResult{}, err
+			}
+			if err := waitFor(8*time.Second, func() bool {
+				return hasFrame(&obsMu, &obs, func(of observedFrame) bool {
+					return of.Subject == "repl.room.index" &&
+						of.Frame.Type == "line" &&
+						strings.Contains(of.Frame.Message, "- user-1 (room=index version=v1.2.3)")
+				})
+			}); err != nil {
+				return testv1.StepRunResult{}, fmt.Errorf("who output with version not observed: %w\n%s", err, snapshotFrames(&obsMu, &obs, 80))
+			}
+			if err := publish(nc, "repl.cmd", repl.BusFrame{Type: "command", From: "user-1", Room: "index", Version: "v1.2.3", Message: "/repl src_v1 versions"}); err != nil {
+				return testv1.StepRunResult{}, err
+			}
+			if err := waitFor(8*time.Second, func() bool {
+				return hasFrame(&obsMu, &obs, func(of observedFrame) bool {
+					return of.Subject == "repl.room.index" &&
+						of.Frame.Type == "line" &&
+						strings.Contains(of.Frame.Message, "- user-1 version=v1.2.3 room=index")
+				})
+			}); err != nil {
+				return testv1.StepRunResult{}, fmt.Errorf("versions output not observed: %w\n%s", err, snapshotFrames(&obsMu, &obs, 80))
+			}
 
 			stage.Store("chat-index")
 			if err := publish(nc, "repl.room.index", repl.BusFrame{Type: "chat", From: "user-1", Room: "index", Message: "hello from user-1"}); err != nil {

--- a/src/plugins/repl/src_v1/test/cmd/main.go
+++ b/src/plugins/repl/src_v1/test/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	testplugin "dialtone/dev/plugins/repl/src_v1/test/04_test_plugin"
 	chromeplugin "dialtone/dev/plugins/repl/src_v1/test/05_chrome_plugin"
 	gobunplugins "dialtone/dev/plugins/repl/src_v1/test/06_go_bun_plugins"
+	multiplayerrobot "dialtone/dev/plugins/repl/src_v1/test/100_multiplayer_robot"
 	multiplayer "dialtone/dev/plugins/repl/src_v1/test/99_multiplayer"
 	testv1 "dialtone/dev/plugins/test/src_v1/go"
 )
@@ -26,6 +27,9 @@ func main() {
 	switch mode {
 	case "multiplayer":
 		multiplayer.Register(reg)
+	case "multiplayer-robot":
+		multiplayer.Register(reg)
+		multiplayerrobot.Register(reg)
 	default:
 		replcore.Register(reg)
 		procplugin.Register(reg)
@@ -34,6 +38,7 @@ func main() {
 		chromeplugin.Register(reg)
 		gobunplugins.Register(reg)
 		multiplayer.Register(reg)
+		multiplayerrobot.Register(reg)
 	}
 
 	logs.Info("Running repl src_v1 tests in single process (%d steps, mode=%s)", len(reg.Steps), mode)


### PR DESCRIPTION
## Summary
- add `/repl src_v1 who` and `/repl src_v1 versions` leader commands
- include client REPL version in join and command frames
- track live presence in leader and print room+version
- add multiplayer tests for who/versions output
- add live robot multiplayer test suite and README updates

## Validation
- ./dialtone.sh repl src_v1 test multiplayer
- ./dialtone.sh repl src_v1 test multiplayer-robot
