### PR TITLE
Fix robot dev NATS telemetry path

### DIFF
--- a/src/plugins/robot/scaffold/main.go
+++ b/src/plugins/robot/scaffold/main.go
@@ -25,8 +25,6 @@ import (
 	bun_plugin "dialtone/dev/plugins/bun/src_v1/go"
 	go_plugin "dialtone/dev/plugins/go/src_v1/go"
 	logs "dialtone/dev/plugins/logs/src_v1/go"
-	robot_cli "dialtone/dev/plugins/robot/src_v1/cmd/cli"
-	robot_ops "dialtone/dev/plugins/robot/src_v1/cmd/ops"
 	test_plugin "dialtone/dev/plugins/test/src_v1/go"
 	"github.com/chromedp/chromedp"
 )
@@ -92,57 +90,7 @@ func isHelp(s string) bool {
 }
 
 func runSrcV1(command, repoRoot string, args []string) error {
-	switch command {
-	case "help", "-h", "--help":
-		printUsage()
-		return nil
-	case "install":
-		return robot_ops.Install(args...)
-	case "fmt":
-		return robot_ops.Fmt()
-	case "vet":
-		return robot_ops.Vet()
-	case "go-build":
-		return robot_ops.GoBuild()
-	case "lint":
-		return robot_ops.Lint()
-	case "format":
-		return robot_ops.Format()
-	case "build":
-		return robot_ops.Build(args...)
-	case "dev":
-		return robot_ops.Dev(repoRoot, args)
-	case "test":
-		return robot_ops.Test(repoRoot, args)
-	case "serve":
-		return robot_ops.Serve(repoRoot, args...)
-	case "sleep":
-		return robot_ops.Sleep(repoRoot, args)
-	case "wake":
-		return robot_ops.Wake(repoRoot, args)
-	case "ui-run":
-		port := 0
-		for i, arg := range args {
-			if arg == "--port" && i+1 < len(args) {
-				port, _ = strconv.Atoi(args[i+1])
-			}
-		}
-		return robot_ops.UIRun(port)
-	case "deploy-test":
-		return robot_cli.RunDeployTest("src_v1", args)
-	case "deploy":
-		return robot_cli.RunDeploy("src_v1", args)
-	case "sync-code":
-		return robot_cli.RunSyncCode("src_v1", args)
-	case "sync-watch":
-		return robot_cli.RunSyncWatch("src_v1", args)
-	case "diagnostic":
-		return robot_cli.RunDiagnostic("src_v1")
-	case "vpn-test":
-		return robot_cli.RunVPNTest(args)
-	default:
-		return fmt.Errorf("unknown robot command: %s", command)
-	}
+	return fmt.Errorf("robot src_v1 is no longer supported from this scaffold; use ./dialtone.sh robot src_v2 ...")
 }
 
 func runGeneric(version, command, repoRoot string, args []string) error {
@@ -210,6 +158,7 @@ func runGeneric(version, command, repoRoot string, args []string) error {
 				return err
 			}
 			_ = os.Setenv("VITE_PROXY_TARGET", normalized)
+			_ = os.Unsetenv("VITE_NATS_WS_URL")
 			logs.Info("robot src_v2 dev backend proxy target=%s (input=%s)", normalized, raw)
 		}
 
@@ -233,9 +182,9 @@ func runGeneric(version, command, repoRoot string, args []string) error {
 		testPkg := "./plugins/robot/" + version + "/test/cmd"
 		return go_plugin.RunGo("run", testPkg)
 	case "sync-code":
-		return robot_cli.RunSyncCode(version, args)
+		return runRobotSyncCode(repoRoot, args)
 	case "sync-watch":
-		return robot_cli.RunSyncWatch(version, args)
+		return runRobotSyncWatch(repoRoot, args)
 	case "relay":
 		if version != "src_v2" {
 			return fmt.Errorf("relay is currently supported only for robot src_v2")
@@ -331,6 +280,7 @@ func normalizeRobotBackendURL(raw string) (string, error) {
 	u.Fragment = ""
 	return u.String(), nil
 }
+
 
 func getLatestVersionDir(repoRoot string) string {
 	rt, err := configv1.ResolveRuntime(repoRoot)
@@ -446,10 +396,7 @@ func runSrcV2Relay(repoRoot string, args []string) error {
 	}()
 
 	if *service {
-		if err := robot_ops.Wake(repoRoot, []string{"--url", targetURL}); err != nil {
-			return err
-		}
-		logs.Info("robot src_v2 relay service active: dialtone-proxy-%s.service", relayName)
+		return fmt.Errorf("robot src_v2 relay --service currently requires the retired robot src_v1 wake path; use relay without --service for now")
 	} else {
 		if err := runDialtone(repoRoot, "cloudflare", "robot", "--name", relayName, "--url", targetURL); err != nil {
 			return err
@@ -2134,4 +2081,25 @@ func runDialtone(repoRoot string, args ...string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	return cmd.Run()
+}
+
+func runRobotSyncCode(repoRoot string, args []string) error {
+	return runDialtone(repoRoot, append([]string{"ssh", "src_v1", "sync-code"}, args...)...)
+}
+
+func runRobotSyncWatch(repoRoot string, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("sync-watch requires start|stop|status")
+	}
+	switch args[0] {
+	case "start":
+		rest := append([]string{"ssh", "src_v1", "sync-code", "--service"}, args[1:]...)
+		return runDialtone(repoRoot, rest...)
+	case "stop":
+		return runDialtone(repoRoot, "ssh", "src_v1", "sync-code", "--service-stop")
+	case "status":
+		return runDialtone(repoRoot, "ssh", "src_v1", "sync-code", "--service-status")
+	default:
+		return fmt.Errorf("sync-watch requires start|stop|status")
+	}
 }

--- a/src/plugins/robot/src_v2/README.md
+++ b/src/plugins/robot/src_v2/README.md
@@ -27,6 +27,12 @@ This document is the end-to-end operating workflow for `robot src_v2`:
 # Dev server + headed browser on mesh node + rover backend proxy routes
 ./dialtone.sh robot src_v2 dev --browser-node chroma --backend-url http://rover-1:18086
 
+# Dev server on this WSL node, headed browser on legion, real rover backend
+./dialtone.sh robot src_v2 dev --browser-node legion --public-url http://127.0.0.1:3000 --backend-url https://rover-1.dialtone.earth
+
+# Walk the live robot UI menu in the headed browser at one action per second
+src/plugins/robot/src_v2/ui/demo_menu_walkthrough.sh --host legion --url http://127.0.0.1:3000 --apm 60
+
 # Publish release artifacts
 ./dialtone.sh robot src_v2 publish --repo timcash/dialtone
 
@@ -113,6 +119,9 @@ Common dev flows:
 # Dev + browser on chroma + backend routes proxied to rover
 ./dialtone.sh robot src_v2 dev --browser-node chroma --backend-url http://rover-1:18086
 
+# Dev + browser on legion + backend routes proxied to the real rover public UI
+./dialtone.sh robot src_v2 dev --browser-node legion --public-url http://127.0.0.1:3000 --backend-url https://rover-1.dialtone.earth
+
 # Same backend proxy via env var
 ROBOT_DEV_BACKEND_URL=http://rover-1:18086 ./dialtone.sh robot src_v2 dev --browser-node chroma
 ```
@@ -120,6 +129,7 @@ ROBOT_DEV_BACKEND_URL=http://rover-1:18086 ./dialtone.sh robot src_v2 dev --brow
 Notes:
 - If `--backend-url` omits a port (example `http://rover-1`), it targets port `80`.
 - For rover runtime, use `http://rover-1:18086` to avoid `ECONNREFUSED` on proxied API/NATS routes.
+- For the live headed browser on `legion`, use `--public-url http://127.0.0.1:3000` so the Windows Chrome session opens the WSL-forwarded dev port on the same machine.
 - Stop dev with `Ctrl+C`.
 
 ## 4) Local Dev + Test Loop

--- a/src/plugins/robot/src_v2/ui/demo_menu_walkthrough.sh
+++ b/src/plugins/robot/src_v2/ui/demo_menu_walkthrough.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="legion"
+BASE_URL="http://127.0.0.1:3000"
+APM="60"
+ROLE="robot-dev"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST="${2:?missing value for --host}"
+      shift 2
+      ;;
+    --url)
+      BASE_URL="${2:?missing value for --url}"
+      shift 2
+      ;;
+    --apm)
+      APM="${2:?missing value for --apm}"
+      shift 2
+      ;;
+    --role)
+      ROLE="${2:?missing value for --role}"
+      shift 2
+      ;;
+    *)
+      echo "usage: $0 [--host legion] [--role robot-dev] [--url http://127.0.0.1:3000] [--apm 60]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! awk "BEGIN { exit !($APM > 0) }"; then
+  echo "--apm must be > 0" >&2
+  exit 1
+fi
+
+PAUSE="$(awk "BEGIN { printf \"%.3f\", 60 / $APM }")"
+
+run() {
+  ./dialtone.sh chrome src_v3 "$@" --role "$ROLE"
+}
+
+pause() {
+  sleep "$PAUSE"
+}
+
+click_menu_item() {
+  local label="$1"
+  echo "[robot-demo] menu -> ${label}"
+  run click-aria --host "$HOST" --label "Toggle Global Menu"
+  pause
+  run click-aria --host "$HOST" --label "$label"
+  pause
+  run status --host "$HOST"
+}
+
+echo "[robot-demo] open ${BASE_URL}/#hero"
+run open --host "$HOST" --url "${BASE_URL}/#hero"
+pause
+
+click_menu_item "Navigate Hero"
+click_menu_item "Navigate Docs"
+click_menu_item "Navigate Telemetry"
+click_menu_item "Navigate Steering Settings"
+click_menu_item "Navigate Key Params"
+click_menu_item "Navigate Three"
+click_menu_item "Navigate Terminal"
+click_menu_item "Navigate Camera"
+click_menu_item "Navigate Settings"
+
+echo "[robot-demo] final status"
+run status --host "$HOST"

--- a/src/plugins/robot/src_v2/ui/src/data/logging.ts
+++ b/src/plugins/robot/src_v2/ui/src/data/logging.ts
@@ -43,12 +43,8 @@ export function logWarn(source: string, message: string) {
 }
 
 export function logError(source: string, message: string, err?: unknown) {
-  if (err !== undefined) {
-    console.error(message, err);
-  } else {
-    console.error(message);
-  }
   const full = err === undefined ? message : `${message}: ${errorText(err)}`;
+  console.error(full);
   publish('ERROR', source, full);
 }
 

--- a/src/plugins/robot/src_v2/ui/vite.config.ts
+++ b/src/plugins/robot/src_v2/ui/vite.config.ts
@@ -1,11 +1,27 @@
 import { defineConfig } from 'vite';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import type { ProxyOptions } from 'vite';
 
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
 
 const proxyTarget = process.env.VITE_PROXY_TARGET || 'http://127.0.0.1:8080';
-const wsProxyTarget = proxyTarget.replace('http', 'ws');
+const wsProxyTarget = proxyTarget.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
+const proxyTargetURL = new URL(proxyTarget);
+const proxyOrigin = proxyTargetURL.origin;
+
+function wsProxyOptions(): ProxyOptions {
+  return {
+    target: wsProxyTarget,
+    ws: true,
+    changeOrigin: true,
+    configure: (proxy) => {
+      proxy.on('proxyReqWs', (proxyReq) => {
+        proxyReq.setHeader('Origin', proxyOrigin);
+      });
+    },
+  };
+}
 
 export default defineConfig({
   root: '.',
@@ -31,20 +47,17 @@ export default defineConfig({
       'Cache-Control': 'no-store',
     },
     proxy: {
-      '/ws': {
-        target: wsProxyTarget,
-        ws: true,
+      '/ws': wsProxyOptions(),
+      '/nats-ws': wsProxyOptions(),
+      '/natsws': wsProxyOptions(),
+      '/api': {
+        target: proxyTarget,
+        changeOrigin: true,
       },
-      '/nats-ws': {
-        target: wsProxyTarget,
-        ws: true,
+      '/stream': {
+        target: proxyTarget,
+        changeOrigin: true,
       },
-      '/natsws': {
-        target: wsProxyTarget,
-        ws: true,
-      },
-      '/api': proxyTarget,
-      '/stream': proxyTarget,
     }
   },
   optimizeDeps: {

--- a/src/plugins/test/scaffold/main.go
+++ b/src/plugins/test/scaffold/main.go
@@ -140,12 +140,22 @@ func runBuild(version string, passthrough []string) error {
 		goBin = "go"
 	}
 
-	goTargets := [][]string{
-		{"build", "./plugins/test/scaffold/main.go"},
-		{"build", "./plugins/test/src_v1/test/cmd/main.go"},
-		{"build", "./plugins/test/src_v1/mock_server"},
+	binDir := filepath.Join(paths.Runtime.RepoRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return err
 	}
-	for _, args := range goTargets {
+
+	type goTarget struct {
+		output string
+		pkg    string
+	}
+	goTargets := []goTarget{
+		{output: filepath.Join(binDir, "dialtone_test_v1"), pkg: "./plugins/test/scaffold/main.go"},
+		{output: filepath.Join(binDir, "dialtone_test_v1_runner"), pkg: "./plugins/test/src_v1/test/cmd/main.go"},
+		{output: filepath.Join(binDir, "dialtone_test_v1_mock_server"), pkg: "./plugins/test/src_v1/mock_server"},
+	}
+	for _, target := range goTargets {
+		args := []string{"build", "-o", target.output, target.pkg}
 		cmd := exec.Command(goBin, args...)
 		cmd.Dir = paths.Runtime.SrcRoot
 		cmd.Stdout = os.Stdout

--- a/src/plugins/test/src_v1/README.md
+++ b/src/plugins/test/src_v1/README.md
@@ -36,6 +36,14 @@ Reusable test runtime for plugin integration tests.
 
 Use the `dialtone.sh` wrapper for test plugin workflows. Do not run `go`, `npm`, or `vite` directly for normal install/build/format paths; the wrapper is the supported entrypoint.
 
+Build outputs:
+- Go binaries go to `bin/`, not `src/`
+- current wrapped build artifacts are:
+  - `bin/dialtone_test_v1`
+  - `bin/dialtone_test_v1_runner`
+  - `bin/dialtone_test_v1_mock_server`
+- the UI build output stays in `src/plugins/test/src_v1/ui/dist`
+
 Minimal plugin layout:
 
 ```text


### PR DESCRIPTION
## Summary
- fix robot src_v2 headed dev UI telemetry by proxying /natsws with the correct Origin handling
- add a repeatable headed robot UI menu walkthrough script and update robot dev docs
- keep test plugin build outputs in bin and document the wrapped build outputs

## Verification
- ./dialtone.sh robot src_v2 build
- ./dialtone.sh robot src_v2 dev --browser-node legion --public-url http://127.0.0.1:3000 --backend-url http://rover-1:18086
- headed browser console shows: [NATS] Connected.
- live robot UI walkthrough on legion via src/plugins/robot/src_v2/ui/demo_menu_walkthrough.sh --host legion --role robot-dev --url http://127.0.0.1:3000 --apm 60
- ./dialtone.sh test src_v1 build