### PR TITLE
Make UI src_v1 tests REPL-aware with Chrome v3 defaults

### DIFF
--- a/src/plugins/ui/src_v1/README.md
+++ b/src/plugins/ui/src_v1/README.md
@@ -1,5 +1,26 @@
 # UI src_v1 Library
 
+## Runtime Note
+
+Plain `./dialtone.sh ui src_v1 test ...` is the default operator path.
+
+That command is normally routed through the local REPL leader, which means:
+- `DIALTONE>` should stay high-level
+- detailed test output stays in the subtone log
+- use `./dialtone.sh repl src_v3 subtone-list --count 20`
+- use `./dialtone.sh repl src_v3 subtone-log --pid <pid> --lines 200`
+
+For WSL, the default remote headed browser path now targets `legion` through `chrome src_v3`.
+
+Typical test summaries are:
+
+```text
+DIALTONE> ui test: preparing remote chrome session on legion
+DIALTONE> ui test: ensuring chrome src_v3 role=dev on legion
+DIALTONE> ui test: running 1 suite steps
+DIALTONE> ui test: suite passed
+```
+
 ```sh
 # generic plugin workflow
 ./dialtone.sh ui src_v1 install
@@ -11,9 +32,17 @@
 ./dialtone.sh ui src_v1 test
 
 # useful variants
+# Run the full suite via the local REPL path.
+./dialtone.sh ui src_v1 test
+
+# Run one headed attach test against the managed Chrome v3 daemon on legion.
 ./dialtone.sh ui src_v1 dev --browser-node legion
 ./dialtone.sh ui src_v1 test --attach legion
-./dialtone.sh ui src_v1 test --filter ui-section-hero-via-menu
+./dialtone.sh ui src_v1 test --attach legion --filter ui-build-and-go-serve
+
+# Inspect the subtone log if the high-level transcript is not enough.
+./dialtone.sh repl src_v3 subtone-list --count 10
+./dialtone.sh repl src_v3 subtone-log --pid <pid> --lines 200
 ```
 
 `src/plugins/ui/src_v1/ui` is the shared section shell used by plugin UIs (robot, earth, fixture apps).

--- a/src/plugins/ui/src_v1/test/browser.go
+++ b/src/plugins/ui/src_v1/test/browser.go
@@ -34,7 +34,7 @@ func BrowserOptionsFor(defaultURL string) (testv1.BrowserOptions, bool, error) {
 		if isWSL() && strings.TrimSpace(os.Getenv("DIALTONE_UI_TEST_FORCE_LOCAL")) == "" {
 			defaultNode := strings.TrimSpace(os.Getenv("DIALTONE_UI_TEST_ATTACH_DEFAULT"))
 			if defaultNode == "" {
-				defaultNode = "darkmac"
+				defaultNode = "legion"
 			}
 			if defaultNode != "" {
 				rewritten := strings.TrimSpace(b.URL)

--- a/src/plugins/ui/src_v1/test/cmd/main.go
+++ b/src/plugins/ui/src_v1/test/cmd/main.go
@@ -58,6 +58,7 @@ func main() {
 			})
 			logs.Info("ui test auto-enabled --no-ssh for windows attach node=%s", attach)
 		}
+		test.ReplIndexInfof("ui test: preparing remote chrome session on %s", attach)
 		logs.Info("ui test remote attach mode (headed) node=%s url=%s apm=%.3f", attach, url, common.ActionsPerMinute)
 		if err := ensureAttachBrowser(attach, url); err != nil {
 			logs.Error("ui test attach preflight failed: %v", err)
@@ -75,6 +76,7 @@ func main() {
 			cfg.RemoteNoLaunch = false
 			cfg.RemoteBrowserPID = 0
 		})
+		test.ReplIndexInfof("ui test: running in local browser mode")
 		logs.Info("ui test local mode url=%s apm=%.3f", url, common.ActionsPerMinute)
 	}
 
@@ -94,6 +96,7 @@ func main() {
 	if filtered := filterSteps(reg.Steps, strings.TrimSpace(common.FilterExpr)); len(filtered) > 0 {
 		reg.Steps = filtered
 	}
+	test.ReplIndexInfof("ui test: running %d suite steps", len(reg.Steps))
 	logs.Info("Starting UI src_v1 suite with %d registered steps", len(reg.Steps))
 	runErr := reg.Run(common.ApplySuiteOptions(testv1.SuiteOptions{
 		Version:            "ui-src-v1",
@@ -102,7 +105,7 @@ func main() {
 		ReportFormat:       "template",
 		ReportTitle:        "UI Plugin src_v1 Test Report",
 		ReportRunner:       "test/src_v1",
-		NATSURL:            "nats://127.0.0.1:4222",
+		NATSURL:            test.ResolveSuiteNATSURL(),
 		NATSSubject:        "logs.test.ui.src-v1",
 		AutoStartNATS:      true,
 		BrowserCleanupRole: "ui-test",
@@ -111,6 +114,7 @@ func main() {
 		logs.Error("UI src_v1 suite failed: %v", runErr)
 		os.Exit(1)
 	}
+	test.ReplIndexInfof("ui test: suite passed")
 	logs.Info("UI src_v1 suite passed")
 }
 
@@ -127,6 +131,7 @@ func ensureAttachBrowser(node, url string) error {
 	if role == "" {
 		role = "dev"
 	}
+	test.ReplIndexInfof("ui test: ensuring chrome src_v3 role=%s on %s", role, node)
 	if _, err := chromev3.EnsureRemoteServiceByHost(node, role, true); err != nil {
 		return err
 	}

--- a/src/plugins/ui/src_v1/test/cmd_ctxdiag/main.go
+++ b/src/plugins/ui/src_v1/test/cmd_ctxdiag/main.go
@@ -44,6 +44,7 @@ func main() {
 
 	reg := test.NewRegistry()
 	ctxdiag.Register(reg)
+	test.ReplIndexInfof("ui test: running context-cancel diagnostic")
 	runErr := reg.Run(testv1.SuiteOptions{
 		Version:               "ui-src-v1-ctxdiag",
 		ReportPath:            "plugins/ui/src_v1/CTX_DIAG_TEST.md",
@@ -51,7 +52,7 @@ func main() {
 		ReportFormat:          "template",
 		ReportTitle:           "UI src_v1 Context Canceled Diagnostic",
 		ReportRunner:          "test/src_v1",
-		NATSURL:               "nats://127.0.0.1:4222",
+		NATSURL:               test.ResolveSuiteNATSURL(),
 		NATSSubject:           "logs.test.ui.src-v1.ctxdiag",
 		AutoStartNATS:         true,
 		BrowserCleanupRole:    "ui-test",
@@ -62,5 +63,6 @@ func main() {
 		logs.Error("ui src_v1 context-cancel diagnostic failed: %v", runErr)
 		os.Exit(1)
 	}
+	test.ReplIndexInfof("ui test: context-cancel diagnostic passed")
 	logs.Info("ui src_v1 context-cancel diagnostic passed")
 }

--- a/src/plugins/ui/src_v1/test/repl_runtime.go
+++ b/src/plugins/ui/src_v1/test/repl_runtime.go
@@ -1,0 +1,19 @@
+package test
+
+import (
+	"os"
+	"strings"
+
+	"dialtone/dev/plugins/logs/src_v1/go"
+)
+
+func ResolveSuiteNATSURL() string {
+	if v := strings.TrimSpace(os.Getenv("DIALTONE_REPL_NATS_URL")); v != "" {
+		return v
+	}
+	return "nats://127.0.0.1:4222"
+}
+
+func ReplIndexInfof(format string, args ...any) {
+	logs.Info("DIALTONE_INDEX: "+format, args...)
+}

--- a/src/plugins/ui/src_v1/test/suite.go
+++ b/src/plugins/ui/src_v1/test/suite.go
@@ -21,7 +21,7 @@ func RunSuiteV1(reg *Registry) error {
 		ReportFormat:          "template",
 		ReportTitle:           "UI Plugin src_v1 Test Report",
 		ReportRunner:          "test/src_v1",
-		NATSURL:               "nats://127.0.0.1:4222",
+		NATSURL:               ResolveSuiteNATSURL(),
 		NATSSubject:           "logs.test.ui.src-v1",
 		AutoStartNATS:         true,
 		BrowserCleanupRole:    "ui-test",


### PR DESCRIPTION
## Summary
- route ui src_v1 test suite logging through the active REPL NATS URL instead of hardcoding 127.0.0.1:4222
- default WSL headed attach runs to legion so UI tests use the Chrome src_v3 path we validated
- add concise REPL-first operator notes to the UI README and promote high-level DIALTONE summaries during test runs

## Verification
- ./dialtone.sh ui src_v1 test --attach legion --filter ui-build-and-go-serve