### PR TITLE
mods: move repl and ssh v1 to flake-backed shells

### DIFF
--- a/dialtone_mod
+++ b/dialtone_mod
@@ -4,7 +4,33 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${DIALTONE_REPO_ROOT:-$SCRIPT_DIR}"
 USE_NIX="${DIALTONE_USE_NIX:-1}"
+NIXPKGS_FLAKE_REF="${DIALTONE_NIXPKGS_FLAKE:-${NIXPKGS_FLAKE:-nixpkgs}}"
 declare -a DIALTONE_NIX_PACKAGES=()
+
+rewrite_nix_package_ref() {
+  local pkg="${1:-}"
+  if [[ "$pkg" == nixpkgs#* ]] && [ "$NIXPKGS_FLAKE_REF" != "nixpkgs" ]; then
+    printf '%s#%s' "$NIXPKGS_FLAKE_REF" "${pkg#nixpkgs#}"
+    return
+  fi
+  printf '%s' "$pkg"
+}
+
+resolve_flake_shell() {
+  local mod="${1:-}"
+  local version="${2:-}"
+  case "${mod}:${version}" in
+    "repl:v1")
+      printf '%s' "repl-v1"
+      ;;
+    "ssh:v1")
+      printf '%s' "ssh-v1"
+      ;;
+    *)
+      printf '%s' ""
+      ;;
+  esac
+}
 
 if [ ! -f "$REPO_ROOT/src/cli.go" ]; then
   echo "DIALTONE> src/cli.go not found under $REPO_ROOT" >&2
@@ -21,6 +47,7 @@ add_nix_package() {
   if [ -z "$pkg" ]; then
     return
   fi
+  pkg="$(rewrite_nix_package_ref "$pkg")"
   local existing=""
   for existing in "${DIALTONE_NIX_PACKAGES[@]:-}"; do
     if [ "$existing" = "$pkg" ]; then
@@ -99,20 +126,51 @@ join_nix_package_sig() {
 
 load_mod_nix_packages "${1:-}" "${2:-}"
 NIX_PACKAGE_SIG="$(join_nix_package_sig)"
+FLAKE_SHELL="$(resolve_flake_shell "${1:-}" "${2:-}")"
 
-if [ "$USE_NIX" != "0" ] && { [ "${DIALTONE_NIX_ACTIVE:-0}" != "1" ] || [ "${DIALTONE_NIX_PACKAGES_SIG:-}" != "$NIX_PACKAGE_SIG" ]; }; then
+if [ "$USE_NIX" != "0" ] && [ -n "$FLAKE_SHELL" ] && { [ "${DIALTONE_NIX_ACTIVE:-0}" != "1" ] || [ "${DIALTONE_NIX_SHELL:-}" != "$FLAKE_SHELL" ]; }; then
   if ! command -v nix >/dev/null 2>&1; then
     echo "DIALTONE> nix is required for dialtone_mod (set DIALTONE_USE_NIX=0 to bypass)" >&2
     exit 1
   fi
+  NIX_ARGS=()
+  if [ "${DIALTONE_NIX_OFFLINE:-0}" = "1" ]; then
+    NIX_ARGS+=(--offline)
+  fi
   exec nix \
+    "${NIX_ARGS[@]}" \
+    --extra-experimental-features "nix-command flakes" \
+    develop "path:$REPO_ROOT#$FLAKE_SHELL" \
+    --command env \
+      DIALTONE_NIX_ACTIVE=1 \
+      DIALTONE_NIX_SHELL="$FLAKE_SHELL" \
+      DIALTONE_REPO_ROOT="$REPO_ROOT" \
+      DIALTONE_NIX_OFFLINE="${DIALTONE_NIX_OFFLINE:-0}" \
+      DIALTONE_USE_NIX="$USE_NIX" \
+      "$REPO_ROOT/dialtone_mod" "$@"
+fi
+
+if [ "$USE_NIX" != "0" ] && [ -z "$FLAKE_SHELL" ] && { [ "${DIALTONE_NIX_ACTIVE:-0}" != "1" ] || [ "${DIALTONE_NIX_PACKAGES_SIG:-}" != "$NIX_PACKAGE_SIG" ]; }; then
+  if ! command -v nix >/dev/null 2>&1; then
+    echo "DIALTONE> nix is required for dialtone_mod (set DIALTONE_USE_NIX=0 to bypass)" >&2
+    exit 1
+  fi
+  NIX_ARGS=()
+  if [ "${DIALTONE_NIX_OFFLINE:-0}" = "1" ]; then
+    NIX_ARGS+=(--offline)
+  fi
+  exec nix \
+    "${NIX_ARGS[@]}" \
     --extra-experimental-features "nix-command flakes" \
     shell \
     "${DIALTONE_NIX_PACKAGES[@]}" \
     --command env \
       DIALTONE_NIX_ACTIVE=1 \
       DIALTONE_NIX_PACKAGES_SIG="$NIX_PACKAGE_SIG" \
+      DIALTONE_NIXPKGS_FLAKE="$NIXPKGS_FLAKE_REF" \
+      NIXPKGS_FLAKE="$NIXPKGS_FLAKE_REF" \
       DIALTONE_REPO_ROOT="$REPO_ROOT" \
+      DIALTONE_NIX_OFFLINE="${DIALTONE_NIX_OFFLINE:-0}" \
       DIALTONE_USE_NIX="$USE_NIX" \
       "$REPO_ROOT/dialtone_mod" "$@"
 fi

--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,56 @@
       mkPerSystem = system:
         let
           pkgs = import nixpkgs { inherit system; };
+          baseDevPackages = with pkgs; [
+            bash curl git gh go_1_24 gnumake nodejs bun tmux zsh cloudflared
+          ] ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+            Security
+            CoreFoundation
+            IOKit
+          ]));
+          mkShellHook = shellName: ''
+            export DIALTONE_REPO_ROOT="''${DIALTONE_REPO_ROOT:-$(pwd)}"
+            export DIALTONE_NIX_ACTIVE=1
+            export DIALTONE_NIX_SHELL="${shellName}"
+            export DIALTONE_SSH_CONFIG="$DIALTONE_REPO_ROOT/env/ssh_config"
+            export DIALTONE_NIX_BASE_PATH="$PATH"
+            export DIALTONE_GO_BIN="$(PATH="$DIALTONE_NIX_BASE_PATH" command -v go)"
+            if PATH="$DIALTONE_NIX_BASE_PATH" command -v ssh >/dev/null 2>&1; then
+              export DIALTONE_SSH_BIN="$(PATH="$DIALTONE_NIX_BASE_PATH" command -v ssh)"
+            else
+              unset DIALTONE_SSH_BIN || true
+            fi
+            export PATH="$DIALTONE_REPO_ROOT/bin:$PATH"
+
+            if [ -n "$ZSH_VERSION" ]; then
+              fpath=($ZSH/functions $ZSH/scripts $fpath)
+              autoload -U compinit && compinit -u
+              zstyle ':completion:*' menu select
+              setopt MENU_COMPLETE
+              bindkey '^I' expand-or-complete
+            fi
+
+            echo "DIALTONE> nix-shell active (${shellName})"
+          '';
+          mkDevShell = { shellName, extraPackages ? [ ] }:
+            pkgs.mkShell {
+              packages = baseDevPackages ++ extraPackages;
+              shellHook = mkShellHook shellName;
+            };
           runtimeScript = { name, text, inputs ? [ ] }:
             pkgs.writeShellApplication {
               inherit name text;
               runtimeInputs = with pkgs; [ bash git go_1_24 ] ++ inputs;
             };
+          dialtoneMod = runtimeScript {
+            name = "dialtone-mod";
+            text = ''
+              set -euo pipefail
+              repo_root="''${DIALTONE_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+              cd "$repo_root"
+              exec ./dialtone_mod "$@"
+            '';
+          };
           robotServer = runtimeScript {
             name = "dialtone-robot-server";
             text = ''
@@ -60,16 +105,31 @@
               exec go run ./src/cli.go repl v1 "$@"
             '';
           };
+          sshModV1 = runtimeScript {
+            name = "dialtone-ssh-v1";
+            text = ''
+              set -euo pipefail
+              repo_root="''${DIALTONE_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+              cd "$repo_root"
+              exec go run ./src/cli.go ssh v1 "$@"
+            '';
+          };
         in
         {
           packages = {
+            dialtone-mod = dialtoneMod;
             robot-server = robotServer;
             camera-service = cameraService;
             mavlink-service = mavlinkService;
             repl-service = replService;
             repl-v1 = replModV1;
+            ssh-v1 = sshModV1;
           };
           apps = {
+            dialtone-mod = {
+              type = "app";
+              program = "${dialtoneMod}/bin/dialtone-mod";
+            };
             robot-server = {
               type = "app";
               program = "${robotServer}/bin/dialtone-robot-server";
@@ -90,33 +150,22 @@
               type = "app";
               program = "${replModV1}/bin/dialtone-repl-v1";
             };
+            ssh-v1 = {
+              type = "app";
+              program = "${sshModV1}/bin/dialtone-ssh-v1";
+            };
           };
           devShells = {
-            default = pkgs.mkShell {
-              packages = with pkgs; [
-                bash curl git gh openssh go_1_24 gnumake nodejs bun tmux zsh cloudflared
-              ] ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
-                Security
-                CoreFoundation
-                IOKit
-              ]));
-              shellHook = ''
-                export DIALTONE_REPO_ROOT=$(pwd)
-                export PATH="$DIALTONE_REPO_ROOT/bin:$PATH"
-                export DIALTONE_SSH_CONFIG="$DIALTONE_REPO_ROOT/env/ssh_config"
-
-                # Initialize completions and set up cycling if in ZSH
-                if [ -n "$ZSH_VERSION" ]; then
-                  fpath=($ZSH/functions $ZSH/scripts $fpath)
-                  autoload -U compinit && compinit -u
-                  zstyle ':completion:*' menu select
-                  setopt MENU_COMPLETE
-                  bindkey '^I' expand-or-complete
-                fi
-
-                export DIALTONE_NIX_ACTIVE=1
-                echo "DIALTONE> nix-shell active"
-              '';
+            default = mkDevShell {
+              shellName = "default";
+              extraPackages = [ pkgs.openssh ];
+            };
+            repl-v1 = mkDevShell {
+              shellName = "repl-v1";
+            };
+            ssh-v1 = mkDevShell {
+              shellName = "ssh-v1";
+              extraPackages = [ pkgs.openssh ];
             };
           };
         };

--- a/plan/MODS_NIX_V1.md
+++ b/plan/MODS_NIX_V1.md
@@ -1,0 +1,425 @@
+# Mods Nix v1 Plan
+
+## Codex Workflow Note
+
+For repeated work on one mod, the preferred Codex workflow is a persistent `nix develop` shell, not one fresh shell per command.
+
+In practice:
+
+- start one PTY session with `nix develop .#repl-v1` or `nix develop .#ssh-v1`
+- keep that shell alive
+- send later commands into that same shell session
+
+That gives two benefits:
+
+1. all later commands in that session use the Nix-provided tools from the flake shell
+2. repeated work is faster because Codex does not pay the `nix develop` startup cost on every command
+
+`./dialtone_mod` is still useful inside that shell because it keeps mod routing consistent, but the fastest development loop is:
+
+```bash
+nix develop .#repl-v1
+./dialtone_mod repl v1 test
+go test ./src/mods/repl/v1/...
+gofmt -w ./src/mods/repl/v1
+```
+
+The same rule applies to `ssh-v1`: enter the flake shell once, then run repeated `./dialtone_mod ssh v1 ...` commands from inside it.
+
+## Current State
+
+Dialtone now has a partially migrated flake-first mod workflow.
+
+Implemented:
+
+- the root flake defines dedicated shells for `repl-v1` and `ssh-v1`
+- `./dialtone_mod repl v1 ...` enters `nix develop path:$REPO_ROOT#repl-v1` when needed
+- `./dialtone_mod ssh v1 ...` enters `nix develop path:$REPO_ROOT#ssh-v1` when needed
+- the flake shells export `DIALTONE_GO_BIN` and `DIALTONE_SSH_BIN`
+- `repl v1` uses the shell-provided `go`
+- `ssh v1` requires the shell-provided Nix `ssh` binary and no longer supports the old nested `nix shell -f ... openssh` path
+
+Still split / not finished:
+
+- mods other than `repl v1` and `ssh v1` still use the older ad hoc package-shell path through `./dialtone_mod`
+- some mod CLIs still construct their own Nix bootstrap logic
+- the flake is not yet the single command surface for all active mods
+- repo docs still assume a mix of workflows in places
+
+That split causes three concrete problems:
+
+1. Reproducibility is weaker than it should be.
+   The repo lock file is authoritative for `repl v1` and `ssh v1`, but not yet for the whole mod surface.
+
+2. Startup is noisier and slower than it should be.
+   Outside a persistent shell, `./dialtone_mod` still has to enter `nix develop` per command. That is correct, but slower than working inside one long-lived shell session.
+
+3. Mod logic is more duplicated than it should be.
+   The first two mods are centralized, but other mods still carry their own bootstrap logic.
+
+## Goal
+
+Make the repository flake the single source of truth for mod development environments and `dialtone_mod` execution.
+
+The desired developer experience is:
+
+- enter the repo once with `nix develop` or `direnv`
+- run `./dialtone_mod <mod> <version> <command>` without re-solving ad hoc package sets
+- optionally enter a focused shell for one mod
+- have a pinned, reproducible environment across machines
+- keep mod-specific runtime/setup logic in the mod, but keep Nix environment construction in one place
+
+## Non-Negotiable Principles
+
+1. The root flake owns the toolchain.
+   `go`, `git`, `bash`, `tmux`, `bun`, `openssh`, and other shared tooling should come from the root flake, not from host tools or scattered `nix shell nixpkgs#...` calls.
+
+2. `dialtone_mod` should be a thin wrapper.
+   It should route commands and enter the appropriate flake-backed environment, not dynamically invent package resolution policy.
+
+3. Mod manifests should remain simple.
+   `src/mods/<mod>/<version>/nix.packages` can remain as lightweight metadata if useful, but it should feed flake generation or a centralized resolver instead of being interpreted independently in many places.
+
+4. Mod `install` commands should not be the primary way to create the dev environment.
+   They should verify prerequisites, perform app-specific setup, or install optional runtime assets. They should not be responsible for reconstructing the base toolchain.
+
+5. Offline and local-cache operation must be first-class.
+   The system should work cleanly with a pinned lock file, cached store paths, `--offline`, and optional local `nixpkgs` references.
+
+6. Development and build commands should use Nix tools, not host tools.
+   If a mod runs through `./dialtone_mod`, its `go`, `ssh`, and similar tool invocations should resolve to Nix-store binaries from the active flake shell.
+
+## Recommended Architecture
+
+## 1. Root Flake Becomes the Only Environment Authority
+
+The root flake should define:
+
+- one default dev shell for general repo work
+- one dev shell per mod/version where a focused environment is useful
+- one app per mod/version command surface where a stable entrypoint is useful
+
+Current shape:
+
+- `devShells.default`
+- `devShells.repl-v1`
+- `devShells.ssh-v1`
+- `apps.dialtone-mod`
+- `apps.repl-v1`
+- `apps.ssh-v1`
+
+Planned next additions:
+
+- `devShells.chrome-v1`
+- `devShells.mosh-v1`
+- `devShells.tsnet-v1`
+- `apps.chrome-v1`
+
+The key point is that `flake.lock` then becomes the real environment lock for mod development.
+
+## 2. `dialtone_mod` Should Use `nix develop path:$REPO_ROOT`
+
+Instead of:
+
+```bash
+nix shell nixpkgs#bashInteractive nixpkgs#git nixpkgs#go_1_24 ...
+```
+
+prefer:
+
+```bash
+nix develop path:$REPO_ROOT#default --command ./dialtone_mod ...
+```
+
+or, for focused shells:
+
+```bash
+nix develop path:$REPO_ROOT#repl-v1 --command ./dialtone_mod repl v1 test
+```
+
+This removes reliance on the caller's `flake:nixpkgs` registry alias and keeps command resolution pinned to the repo lock.
+
+## 3. Generate Remaining Per-Mod Shells from One Central Rule
+
+The mod metadata model should be centralized.
+
+Recommended input:
+
+- shared base packages from the root flake
+- optional per-mod additions from `src/mods/<mod>/<version>/nix.packages`
+- optional platform selectors already supported in the manifest format
+
+Recommended behavior:
+
+- a single flake helper reads or mirrors those manifests
+- the helper produces per-mod package lists
+- dev shells and apps are generated from that data
+
+This preserves the nice part of the current `nix.packages` files without forcing every remaining mod CLI to interpret them separately.
+
+## 4. Split Environment Concerns from Runtime Concerns
+
+There are two different jobs that are currently blurred together:
+
+- constructing a reproducible development shell
+- performing mod-specific operational setup
+
+These should be separated.
+
+Examples:
+
+- `repl v1 install` should verify or initialize REPL-specific state only
+- `mosh v1 install --ensure` may still make sense as an optional runtime convenience if it intentionally installs profile-level binaries
+- `chrome v1 install` may verify browser/runtime availability, but should not need to reconstruct the base shell itself
+
+The base rule should be:
+
+- environment from flake
+- operational setup from mod CLI
+
+## 5. Add `direnv` for the Common Path
+
+For daily development speed, the repo should support:
+
+```bash
+direnv allow
+```
+
+with an `.envrc` equivalent to:
+
+```bash
+use flake
+```
+
+or a small wrapper around the repo flake if extra environment exports are needed.
+
+This matters because the biggest productivity win is not theoretical purity. It is avoiding repeated shell startup and repeated environment reconstruction while moving between mods.
+
+## 6. Keep Offline and Local-Source Support Explicit
+
+The system should support:
+
+- locked flake inputs
+- local `path:` flake references when needed
+- `--offline` when store data is already available
+- optional binary cache use
+
+Practical support knobs:
+
+- `DIALTONE_NIX_OFFLINE=1`
+- `DIALTONE_NIXPKGS_FLAKE=path:/path/to/nixpkgs`
+
+Those are useful escape hatches, but in the target design they should be secondary to the locked repo flake, not part of the normal workflow.
+
+## Mod-Specific Compatibility Notes
+
+### `repl v1`
+
+`repl v1` should fit the new model directly.
+
+Current shape:
+
+- runtime commands live in `src/mods/repl/v1`
+- lifecycle commands live in `src/mods/repl/v1/cli`
+- `nix.packages` is just the shared Go toolchain set
+
+Implications for the migration:
+
+- `repl-v1` should get a dedicated flake dev shell
+- `./dialtone_mod repl v1 run|logs|version` should work inside that shell with no extra ad hoc `nix shell`
+- `repl v1 install` should become a lightweight verification/init command, not a shell-construction command
+- `repl v1 test|build|format` should rely on the flake shell as the default environment source
+
+What must remain true:
+
+- local runtime log paths still resolve relative to the repo
+- `./dialtone_mod repl v1 run --once hello` works from a clean flake-backed shell
+- `./dialtone_mod repl v1 test` works without consulting the caller's global `nixpkgs` registry
+
+### `ssh v1`
+
+Current shape:
+
+- the mod is implemented in a single root package, not a split root/`cli` arrangement
+- it runs only inside the `ssh-v1` flake shell
+- it requires `DIALTONE_SSH_BIN` from that shell
+- it rejects `--nixpkgs-url`
+
+Implications for the migration:
+
+- the normal `ssh v1` path now works only from the root flake or `ssh-v1`
+- this is intentional because the goal is to prevent host-tool fallback
+- the migration pattern for future mods should follow this stricter rule, not the older compatibility rule
+
+Recommended target behavior:
+
+- `./dialtone_mod ssh v1 ...` enters `ssh-v1` when needed
+- inside that shell, `ssh v1` executes only the Nix `ssh` binary from `/nix/...`
+- no nested-Nix override path remains
+- shell contents: `ssh-v1` must include `openssh` in addition to the shared base packages
+
+What must remain true:
+
+- `./dialtone_mod ssh v1 --host gold --dry-run` still shows a valid command path
+- `./dialtone_mod ssh v1 test --host gold` still works from a clean machine after entering the flake shell
+- the printed `ssh` path comes from `/nix/store/...`, not host `/usr/bin/ssh`
+- the migration does not break the current host/alias behavior from `env/mesh.json`
+
+## Proposed Command Model
+
+### Normal Repo Work
+
+```bash
+nix develop
+./dialtone_mod repl v1 test
+./dialtone_mod chrome v1 service status
+```
+
+### Focused Mod Work
+
+```bash
+nix develop .#repl-v1
+./dialtone_mod repl v1 run --once hello
+```
+
+### Fully Explicit Reproducible Command Run
+
+```bash
+nix develop path:$PWD#repl-v1 --command ./dialtone_mod repl v1 test
+```
+
+### App Entry
+
+```bash
+nix run .#repl-v1 -- run --once hello
+```
+
+## Implementation Plan
+
+### Phase 1: Normalize the Flake Surface
+
+1. Add a proper `apps.dialtone-mod` entry to the root flake.
+2. Add per-mod dev shells for the actively used mods first:
+   - `repl-v1`
+   - `ssh-v1`
+   - `chrome-v1`
+   - `mod-v1`
+   - `mosh-v1`
+   - `tsnet-v1`
+3. Ensure those shells include the repo-level exports currently performed in the default `shellHook`.
+4. Export explicit tool paths such as `DIALTONE_GO_BIN` and `DIALTONE_SSH_BIN` from those shells.
+
+Deliverable:
+
+- developers can use the root flake alone to enter both general and focused mod shells
+
+### Phase 2: Refactor `dialtone_mod` to Be Flake-First
+
+1. Replace the primary `nix shell nixpkgs#...` path with `nix develop path:$REPO_ROOT#<shell>`.
+2. Ensure the wrapper selects a default shell or a mod-specific shell deterministically.
+3. Use the flake shell as the only supported environment for migrated mods.
+
+Deliverable:
+
+- `./dialtone_mod` no longer depends on the user's global `nixpkgs` registry alias for normal operation
+
+### Phase 3: Simplify Mod `install` Commands
+
+1. Remove duplicated base-shell construction logic from mod CLIs.
+2. Keep only:
+   - verification of app/runtime prerequisites
+   - optional profile/system installation where intentionally required
+   - mod-local initialization
+3. Document the narrowed meaning of `install` in `src/mods/README.md`.
+4. Apply this first to `repl v1`; `ssh v1` does not have a separate lifecycle CLI, but it should still follow the “Nix shell only, no host tool fallback” rule.
+
+Deliverable:
+
+- mod CLIs stop rebuilding the dev shell on their own
+
+### Phase 4: Add `direnv` Support
+
+1. Add `.envrc` or equivalent documentation.
+2. Make sure `nix develop` and `direnv` expose the same repo variables.
+3. Validate the path behavior for both macOS and Linux.
+4. Document the persistent-shell workflow explicitly for Codex and human users.
+
+Deliverable:
+
+- entering the repo automatically provides a warm shell for repeated mod work
+
+### Phase 5: Optional Cache Improvements
+
+1. Add documentation for local store reuse and offline mode.
+2. If cold-start speed across machines matters, add a binary cache strategy.
+3. Keep this phase optional because it improves speed, not correctness.
+
+Deliverable:
+
+- better cold-start behavior without changing the core contract
+
+## Acceptance Criteria
+
+The migration is complete when all of the following are true:
+
+1. `./dialtone_mod` uses the root flake by default for mod execution.
+2. A clean machine can clone the repo, run `nix develop`, and immediately use active mods reproducibly.
+3. The normal path does not depend on `flake:nixpkgs` global registry resolution.
+4. At least the main active mods have dedicated flake-backed dev shells.
+5. `repl v1` works fully from a flake-backed shell for `run`, `logs`, `test`, and `build`.
+6. `ssh v1` works fully from a flake-backed shell for `run` and `test`, and uses only the Nix `ssh` binary from the active shell.
+7. Migrated mods do not use host `go`, host `ssh`, or similar host tools for development/build/exec paths.
+8. Mod `install` commands no longer duplicate generic Nix shell construction, except for non-migrated mods that have not yet been refactored.
+9. Offline execution works cleanly after inputs are cached locally.
+10. Repo documentation explains the difference between:
+   - dev environment entry
+   - mod command routing
+   - optional runtime installation/setup
+   - persistent shell workflow for repeated work
+
+## Risks
+
+1. Overfitting per-mod shells too early.
+   If every mod gets a special shell immediately, the flake may become harder to maintain than the current system.
+
+2. Mixing environment and provisioning again.
+   If `install` remains vague, the new design will still drift back toward duplicated bootstrap logic.
+
+3. Hidden platform drift.
+   Some mod dependencies differ on Darwin vs Linux; those cases need to remain explicit in the centralized model.
+
+4. Startup cost outside persistent shells.
+   `./dialtone_mod` still has to enter `nix develop` when called from outside a shell. That is correct, but users need a documented persistent-shell workflow for faster iteration.
+
+## Current Status
+
+Already done:
+
+1. add `apps.dialtone-mod`
+2. add `devShells.repl-v1`
+3. add `devShells.ssh-v1`
+4. switch `dialtone_mod` to `nix develop` against the root flake for those two mods
+5. remove the old ad hoc REPL shell path in favor of the flake shell
+6. remove the old nested-Nix SSH path and require Nix-shell `ssh`
+7. export `DIALTONE_GO_BIN` and `DIALTONE_SSH_BIN`
+
+## Recommended Next Slice
+
+The best next implementation slice is:
+
+1. add `devShells.chrome-v1`
+2. add `devShells.mosh-v1`
+3. add `devShells.tsnet-v1`
+4. move those mods off ad hoc `nix shell nixpkgs#...`
+5. update repo docs for `direnv` and persistent-shell development
+6. keep using the same strict rule: migrated mods use Nix tools only, not host tools
+
+That slice extends the proven model instead of introducing a second one.
+
+## Success Metric
+
+The practical success metric is simple:
+
+- a developer can clone the repo, enter one pinned shell, and iterate across mods without fighting Nix, registry lookups, or repeated environment bootstrap code
+
+If that is not true, the design is still too indirect.

--- a/src/mods/README.md
+++ b/src/mods/README.md
@@ -126,6 +126,9 @@ go run ./src/mods/my_mod/v1/cli help
 
 - When `runSSH` is used internally, remote commands are now executed by running `ssh v1` through `dialtone_mod` when available, so remote execution matches local CLI behavior.
 - If `dialtone_mod` is not present on a host, fallback is `go run ./src/cli.go`, which bypasses `dialtone_mod` and may miss the pinned Nix shell behavior.
+- To avoid GitHub-backed `flake:nixpkgs` registry lookups, you can export `DIALTONE_NIXPKGS_FLAKE=<flake-ref>` before running `./dialtone_mod`.
+  - Example local source: `DIALTONE_NIXPKGS_FLAKE=path:/path/to/nixpkgs ./dialtone_mod repl v1 test`
+- To force cached/offline Nix resolution after inputs are already present locally, set `DIALTONE_NIX_OFFLINE=1`.
 
 ## Mesh and Git Safety
 

--- a/src/mods/repl/v1/README.md
+++ b/src/mods/repl/v1/README.md
@@ -5,9 +5,16 @@ Minimal local REPL mod scaffold.
 Run it through the repo CLI:
 
 ```bash
-nix develop --command go run ./src/cli.go repl v1 run
-nix develop --command go run ./src/cli.go repl v1 run --once "hello"
-nix develop --command go run ./src/cli.go repl v1 logs --tail 20
+./dialtone_mod repl v1 run
+./dialtone_mod repl v1 run --once "hello"
+./dialtone_mod repl v1 logs --tail 20
+```
+
+Or enter the focused flake shell first:
+
+```bash
+nix develop .#repl-v1
+./dialtone_mod repl v1 test
 ```
 
 Files stay local to this mod:

--- a/src/mods/repl/v1/cli/main.go
+++ b/src/mods/repl/v1/cli/main.go
@@ -43,7 +43,7 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Println("Usage: go run ./src/cli.go repl v1 <install|build|format|test> [args]")
+	fmt.Println("Usage: ./dialtone_mod repl v1 <install|build|format|test> [args]")
 	fmt.Println("")
 	fmt.Println("Commands:")
 	fmt.Println("  install                                  Verify the repo Nix dev shell can load repl prerequisites")

--- a/src/mods/repl/v1/cli/main_test.go
+++ b/src/mods/repl/v1/cli/main_test.go
@@ -8,7 +8,22 @@ import (
 func TestNixDevelopCommand(t *testing.T) {
 	t.Setenv("DIALTONE_NIX_ACTIVE", "")
 	cmd := nixDevelopCommand("/tmp/dialtone", "go", "test", "./src/mods/repl/v1/...")
-	if got := strings.Join(cmd.Args, " "); !strings.Contains(got, "shell nixpkgs#bashInteractive nixpkgs#git nixpkgs#go_1_24 --command go test ./src/mods/repl/v1/...") {
+	if got := strings.Join(cmd.Args, " "); !strings.Contains(got, "develop path:/tmp/dialtone#repl-v1 --command go test ./src/mods/repl/v1/...") {
 		t.Fatalf("cmd args = %q", got)
+	}
+}
+
+func TestNixDevelopCommandUsesOfflineFlakeDevelop(t *testing.T) {
+	t.Setenv("DIALTONE_NIX_ACTIVE", "")
+	t.Setenv("DIALTONE_NIX_OFFLINE", "1")
+
+	cmd := nixDevelopCommand("/tmp/dialtone", "go", "test", "./src/mods/repl/v1/...")
+	got := strings.Join(cmd.Args, " ")
+
+	if !strings.Contains(got, "--offline") {
+		t.Fatalf("expected offline nix args, got %q", got)
+	}
+	if !strings.Contains(got, "develop path:/tmp/dialtone#repl-v1 --command") {
+		t.Fatalf("expected repl-v1 flake develop in nix args, got %q", got)
 	}
 }

--- a/src/mods/repl/v1/cli/nix.go
+++ b/src/mods/repl/v1/cli/nix.go
@@ -3,29 +3,44 @@ package main
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func nixDevelopCommand(repoRoot string, command ...string) *exec.Cmd {
 	if os.Getenv("DIALTONE_NIX_ACTIVE") == "1" {
-		cmd := exec.Command(command[0], command[1:]...)
-		cmd.Env = append(os.Environ(), "DIALTONE_REPO_ROOT="+repoRoot)
+		argv := append([]string{}, command...)
+		if len(argv) > 0 && argv[0] == "go" {
+			if goBin := strings.TrimSpace(os.Getenv("DIALTONE_GO_BIN")); goBin != "" {
+				argv[0] = goBin
+			}
+		}
+		cmd := exec.Command(argv[0], argv[1:]...)
+		cmd.Env = append(
+			os.Environ(),
+			"DIALTONE_REPO_ROOT="+repoRoot,
+			"DIALTONE_NIX_SHELL=repl-v1",
+		)
 		return cmd
 	}
-	args := []string{
+	args := []string{}
+	if strings.TrimSpace(os.Getenv("DIALTONE_NIX_OFFLINE")) == "1" {
+		args = append(args, "--offline")
+	}
+	args = append(args,
 		"--extra-experimental-features",
 		"nix-command flakes",
-		"shell",
-		"nixpkgs#bashInteractive",
-		"nixpkgs#git",
-		"nixpkgs#go_1_24",
+		"develop",
+		"path:"+repoRoot+"#repl-v1",
 		"--command",
-	}
+	)
 	args = append(args, command...)
 	cmd := exec.Command("nix", args...)
 	cmd.Dir = repoRoot
 	cmd.Env = append(
 		os.Environ(),
 		"DIALTONE_NIX_ACTIVE=1",
+		"DIALTONE_NIX_OFFLINE="+strings.TrimSpace(os.Getenv("DIALTONE_NIX_OFFLINE")),
+		"DIALTONE_NIX_SHELL=repl-v1",
 		"DIALTONE_REPO_ROOT="+repoRoot,
 	)
 	return cmd

--- a/src/mods/repl/v1/main.go
+++ b/src/mods/repl/v1/main.go
@@ -169,7 +169,7 @@ func parseLogsConfig(args []string) (LogsConfig, error) {
 }
 
 func printUsage() {
-	fmt.Println("Usage: go run ./src/cli.go repl v1 <command> [args]")
+	fmt.Println("Usage: ./dialtone_mod repl v1 <command> [args]")
 	fmt.Println("")
 	fmt.Println("Commands:")
 	fmt.Println("  run [--name NAME] [--room ROOM] [--log-file PATH] [--once TEXT]")

--- a/src/mods/ssh/v1/main.go
+++ b/src/mods/ssh/v1/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,7 +14,6 @@ type sshOptions struct {
 	user        string
 	port        string
 	command     string
-	nixpkgsURL  string
 	dryRun      bool
 	showVersion bool
 }
@@ -79,7 +77,7 @@ func runSSHCommand(cfg sshOptions, node meshNode) error {
 			continue
 		}
 		if cfg.dryRun {
-			fmt.Printf("nix command: %s", cmd.Path)
+			fmt.Printf("command: %s", cmd.Path)
 			for _, arg := range cmd.Args[1:] {
 				fmt.Printf(" %q", arg)
 			}
@@ -147,10 +145,7 @@ func runSSHCommandTest(cfg sshOptions, node meshNode) error {
 }
 
 func parseArgs(argv []string) (sshOptions, error) {
-	opts := sshOptions{
-		port:       "",
-		nixpkgsURL: "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz",
-	}
+	opts := sshOptions{port: ""}
 	positional := make([]string, 0)
 
 	for i := 0; i < len(argv); i++ {
@@ -193,12 +188,9 @@ func parseArgs(argv []string) (sshOptions, error) {
 		case strings.HasPrefix(current, "--command="):
 			opts.command = strings.TrimSpace(strings.TrimPrefix(current, "--command="))
 		case strings.EqualFold(current, "--nixpkgs-url"):
-			if i+1 < len(argv) {
-				opts.nixpkgsURL = strings.TrimSpace(argv[i+1])
-				i++
-			}
+			return sshOptions{}, fmt.Errorf("--nixpkgs-url is no longer supported; run ssh v1 through ./dialtone_mod so Dialtone manages the nix shell")
 		case strings.HasPrefix(current, "--nixpkgs-url="):
-			opts.nixpkgsURL = strings.TrimSpace(strings.TrimPrefix(current, "--nixpkgs-url="))
+			return sshOptions{}, fmt.Errorf("--nixpkgs-url is no longer supported; run ssh v1 through ./dialtone_mod so Dialtone manages the nix shell")
 		case strings.EqualFold(current, "--dry-run"):
 			opts.dryRun = true
 		case strings.HasPrefix(current, "--"):
@@ -216,12 +208,12 @@ func parseArgs(argv []string) (sshOptions, error) {
 }
 
 type meshNode struct {
-	Name    string   `json:"name"`
-	Aliases []string `json:"aliases"`
-	User    string   `json:"user"`
-	Host    string   `json:"host"`
+	Name           string   `json:"name"`
+	Aliases        []string `json:"aliases"`
+	User           string   `json:"user"`
+	Host           string   `json:"host"`
 	HostCandidates []string `json:"host_candidates"`
-	Port    string   `json:"port"`
+	Port           string   `json:"port"`
 }
 
 func resolveMeshNode(raw string) (meshNode, error) {
@@ -321,22 +313,7 @@ func buildSSHCommandForHost(cfg sshOptions, node meshNode, host string) (*exec.C
 		remotePort = "22"
 	}
 
-	nixBin := strings.TrimSpace(os.Getenv("NIX_BIN"))
-	if nixBin == "" {
-		var err error
-		nixBin, err = locateNixBinary()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	args := []string{
-		"--extra-experimental-features", "nix-command",
-		"--extra-experimental-features", "flakes",
-		"shell",
-		"-f", cfg.nixpkgsURL,
-		"openssh",
-		"--command", "ssh",
+	sshArgs := []string{
 		"-F", "/dev/null",
 		"-o", "BatchMode=yes",
 		"-o", "StrictHostKeyChecking=no",
@@ -346,15 +323,19 @@ func buildSSHCommandForHost(cfg sshOptions, node meshNode, host string) (*exec.C
 		"-o", "ConnectTimeout=5",
 	}
 	if remotePort != "" && remotePort != "22" {
-		args = append(args, "-p", remotePort)
+		sshArgs = append(sshArgs, "-p", remotePort)
 	}
 	target := fmt.Sprintf("%s@%s", remoteUser, host)
-	args = append(args, target)
+	sshArgs = append(sshArgs, target)
 	if cfg.command != "" {
-		args = append(args, cfg.command)
+		sshArgs = append(sshArgs, cfg.command)
 	}
 
-	return exec.Command(nixBin, args...), nil
+	sshBin, err := shellSSHBinary()
+	if err != nil {
+		return nil, err
+	}
+	return exec.Command(sshBin, sshArgs...), nil
 }
 
 func orderedMeshHostsForSSH(candidates []string, host string) []string {
@@ -413,32 +394,19 @@ func exitIfErr(err error, context string) {
 	os.Exit(1)
 }
 
-func locateNixBinary() (string, error) {
-	if p := strings.TrimSpace(os.Getenv("NIX_BIN")); p != "" {
-		return p, nil
+func shellSSHBinary() (string, error) {
+	if os.Getenv("DIALTONE_NIX_ACTIVE") != "1" {
+		return "", fmt.Errorf("ssh v1 must run inside the Dialtone nix shell; use ./dialtone_mod ssh v1 ...")
 	}
-	if p, err := exec.LookPath("nix"); err == nil {
-		return p, nil
+	sshBin := strings.TrimSpace(os.Getenv("DIALTONE_SSH_BIN"))
+	if sshBin == "" {
+		return "", fmt.Errorf("ssh v1 requires DIALTONE_SSH_BIN from the Dialtone nix shell")
 	}
-
-	candidates := []string{
-		"/usr/local/bin/nix",
-		"/nix/var/nix/profiles/default/bin/nix",
-		filepath.Join(os.Getenv("HOME"), ".nix-profile/bin/nix"),
-		"/run/current-system/sw/bin/nix",
+	clean := filepath.Clean(sshBin)
+	if !strings.HasPrefix(clean, "/nix/") {
+		return "", fmt.Errorf("ssh v1 requires nix-provided ssh, got %s", clean)
 	}
-	for _, c := range candidates {
-		if _, err := os.Stat(c); err == nil {
-			return c, nil
-		}
-	}
-
-	matches, err := filepath.Glob("/nix/store/*-nix-*/bin/nix")
-	if err == nil && len(matches) > 0 {
-		return matches[len(matches)-1], nil
-	}
-
-	return "", errors.New("nix executable not found. Set NIX_BIN or install nix")
+	return clean, nil
 }
 
 var execRunner = func(cmd *exec.Cmd) error {

--- a/src/mods/ssh/v1/main_test.go
+++ b/src/mods/ssh/v1/main_test.go
@@ -46,12 +46,15 @@ func TestSSHParseArgsPositionalHost(t *testing.T) {
 	}
 }
 
+func TestSSHParseArgsRejectsNixpkgsURL(t *testing.T) {
+	_, err := parseArgs([]string{"--host", "gold", "--nixpkgs-url", "nix://example"})
+	if err == nil || !strings.Contains(err.Error(), "no longer supported") {
+		t.Fatalf("expected nixpkgs-url rejection, got %v", err)
+	}
+}
+
 func TestSSHParseArgsHostFallbackFromRunPrefix(t *testing.T) {
 	tmp := t.TempDir()
-	nixPath := filepath.Join(tmp, "fake-nix")
-	if err := os.WriteFile(nixPath, []byte("#!/bin/sh\necho test\n"), 0o755); err != nil {
-		t.Fatalf("write fake nix failed: %v", err)
-	}
 	meshPath := filepath.Join(tmp, "env", "mesh.json")
 
 	if err := os.MkdirAll(filepath.Dir(meshPath), 0o755); err != nil {
@@ -64,13 +67,16 @@ func TestSSHParseArgsHostFallbackFromRunPrefix(t *testing.T) {
 		t.Fatalf("write mesh config failed: %v", err)
 	}
 
-	oldNixBin := os.Getenv("NIX_BIN")
 	oldRepoRoot := os.Getenv("DIALTONE_REPO_ROOT")
-	_ = os.Setenv("NIX_BIN", nixPath)
+	oldActive := os.Getenv("DIALTONE_NIX_ACTIVE")
+	oldSSHBin := os.Getenv("DIALTONE_SSH_BIN")
 	_ = os.Setenv("DIALTONE_REPO_ROOT", tmp)
+	_ = os.Setenv("DIALTONE_NIX_ACTIVE", "1")
+	_ = os.Setenv("DIALTONE_SSH_BIN", "/nix/store/test-openssh/bin/ssh")
 	defer func() {
-		_ = os.Setenv("NIX_BIN", oldNixBin)
 		_ = os.Setenv("DIALTONE_REPO_ROOT", oldRepoRoot)
+		_ = os.Setenv("DIALTONE_NIX_ACTIVE", oldActive)
+		_ = os.Setenv("DIALTONE_SSH_BIN", oldSSHBin)
 	}()
 
 	output := captureStdout(t, func() {
@@ -78,7 +84,7 @@ func TestSSHParseArgsHostFallbackFromRunPrefix(t *testing.T) {
 			t.Fatalf("run with run-prefix failed: %v", err)
 		}
 	})
-	if !strings.Contains(output, "nix command:") {
+	if !strings.Contains(output, "command:") {
 		t.Fatalf("run with run prefix did not emit dry-run command: %q", output)
 	}
 }
@@ -108,50 +114,72 @@ func TestSSHBuildCommandUsesNodeDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseArgs failed: %v", err)
 	}
-	oldNixBin := os.Getenv("NIX_BIN")
-	_ = os.Setenv("NIX_BIN", "/opt/nix/bin/nix")
-	defer func() {
-		_ = os.Setenv("NIX_BIN", oldNixBin)
-	}()
-
-	cmd, err := buildSSHCommand(opts, node)
-	if err != nil {
-		t.Fatalf("buildSSHCommand failed: %v", err)
-	}
-	if got := strings.Join(cmd.Args, " "); !strings.Contains(got, "-p 2223") {
-		t.Fatalf("expected port 2223 from mesh node, got args %q", got)
-	}
-	if !strings.HasSuffix(strings.TrimSpace(cmd.Args[len(cmd.Args)-1]), "@example.com") {
-		t.Fatalf("expected default user target, got target arg %q", cmd.Args[len(cmd.Args)-1])
-	}
+	withShellSSH(t, "/nix/store/test-openssh/bin/ssh", func() {
+		cmd, err := buildSSHCommand(opts, node)
+		if err != nil {
+			t.Fatalf("buildSSHCommand failed: %v", err)
+		}
+		if cmd.Path != "/nix/store/test-openssh/bin/ssh" {
+			t.Fatalf("expected nix shell ssh path, got %q", cmd.Path)
+		}
+		if got := strings.Join(cmd.Args, " "); !strings.Contains(got, "-p 2223") {
+			t.Fatalf("expected port 2223 from mesh node, got args %q", got)
+		}
+		if !strings.HasSuffix(strings.TrimSpace(cmd.Args[len(cmd.Args)-1]), "@example.com") {
+			t.Fatalf("expected default user target, got target arg %q", cmd.Args[len(cmd.Args)-1])
+		}
+	})
 }
 
 func TestSSHBuildCommandRespectsOverrides(t *testing.T) {
 	node := meshNode{Name: "gold", Host: "example.com", User: "user", Port: "2223"}
-	opts, err := parseArgs([]string{"--host", "gold", "--user", "alice", "--port", "2200", "--command", "echo hi", "--nixpkgs-url", "nix://example"})
+	opts, err := parseArgs([]string{"--host", "gold", "--user", "alice", "--port", "2200", "--command", "echo hi"})
 	if err != nil {
 		t.Fatalf("parseArgs failed: %v", err)
 	}
-	oldNixBin := os.Getenv("NIX_BIN")
-	_ = os.Setenv("NIX_BIN", "/opt/nix/bin/nix")
-	defer func() {
-		_ = os.Setenv("NIX_BIN", oldNixBin)
-	}()
+	withShellSSH(t, "/nix/store/test-openssh/bin/ssh", func() {
+		cmd, err := buildSSHCommand(opts, node)
+		if err != nil {
+			t.Fatalf("buildSSHCommand failed: %v", err)
+		}
+		joined := strings.Join(cmd.Args, " ")
+		if !strings.Contains(joined, "-p 2200") {
+			t.Fatalf("expected CLI port override to win, got %q", joined)
+		}
+		if !strings.HasSuffix(strings.TrimSpace(cmd.Args[len(cmd.Args)-2]), "alice@example.com") {
+			t.Fatalf("expected CLI user override, got %q", cmd.Args[len(cmd.Args)-2])
+		}
+		if got := cmd.Args[len(cmd.Args)-1]; got != "echo hi" {
+			t.Fatalf("expected command arg, got %q", got)
+		}
+	})
+}
 
-	cmd, err := buildSSHCommand(opts, node)
-	if err != nil {
-		t.Fatalf("buildSSHCommand failed: %v", err)
+func TestSSHBuildCommandRequiresNixShellSSH(t *testing.T) {
+	node := meshNode{Name: "gold", Host: "example.com", User: "user", Port: "2223"}
+	oldActive := os.Getenv("DIALTONE_NIX_ACTIVE")
+	oldSSHBin := os.Getenv("DIALTONE_SSH_BIN")
+	defer func() {
+		_ = os.Setenv("DIALTONE_NIX_ACTIVE", oldActive)
+		_ = os.Setenv("DIALTONE_SSH_BIN", oldSSHBin)
+	}()
+	_ = os.Setenv("DIALTONE_NIX_ACTIVE", "")
+	_ = os.Setenv("DIALTONE_SSH_BIN", "")
+
+	_, err := buildSSHCommand(sshOptions{}, node)
+	if err == nil || !strings.Contains(err.Error(), "must run inside the Dialtone nix shell") {
+		t.Fatalf("expected nix shell requirement error, got %v", err)
 	}
-	joined := strings.Join(cmd.Args, " ")
-	if !strings.Contains(joined, "-p 2200") {
-		t.Fatalf("expected CLI port override to win, got %q", joined)
-	}
-	if !strings.HasSuffix(strings.TrimSpace(cmd.Args[len(cmd.Args)-2]), "alice@example.com") {
-		t.Fatalf("expected CLI user override, got %q", cmd.Args[len(cmd.Args)-2])
-	}
-	if got := cmd.Args[len(cmd.Args)-1]; got != "echo hi" {
-		t.Fatalf("expected command arg, got %q", got)
-	}
+}
+
+func TestSSHBuildCommandRejectsHostSSHPath(t *testing.T) {
+	node := meshNode{Name: "gold", Host: "example.com", User: "user", Port: "2223"}
+	withShellSSH(t, "/usr/bin/ssh", func() {
+		_, err := buildSSHCommand(sshOptions{}, node)
+		if err == nil || !strings.Contains(err.Error(), "requires nix-provided ssh") {
+			t.Fatalf("expected nix-provided ssh error, got %v", err)
+		}
+	})
 }
 
 func TestSSHBuildCommandPrefersTailnetHostCandidate(t *testing.T) {
@@ -162,82 +190,22 @@ func TestSSHBuildCommandPrefersTailnetHostCandidate(t *testing.T) {
 		User:           "user",
 		Port:           "22",
 	}
-	oldNixBin := os.Getenv("NIX_BIN")
-	_ = os.Setenv("NIX_BIN", "/opt/nix/bin/nix")
-	defer func() {
-		_ = os.Setenv("NIX_BIN", oldNixBin)
-	}()
-
-	cmd, err := buildSSHCommand(sshOptions{}, node)
-	if err != nil {
-		t.Fatalf("buildSSHCommand failed: %v", err)
-	}
-	if !strings.HasSuffix(cmd.Args[len(cmd.Args)-1], "user@gold.shad-artichoke.ts.net") {
-		t.Fatalf("expected tailnet host to be selected first, got target %q", cmd.Args[len(cmd.Args)-1])
-	}
-}
-
-func TestSSHLocateNixBinaryEnvOverride(t *testing.T) {
-	tmp := t.TempDir()
-	fakeNix := filepath.Join(tmp, "nix")
-	if err := os.WriteFile(fakeNix, []byte("#!/bin/sh\necho test\n"), 0o755); err != nil {
-		t.Fatalf("write fake nix failed: %v", err)
-	}
-
-	old := os.Getenv("NIX_BIN")
-	_ = os.Setenv("NIX_BIN", fakeNix)
-	defer func() { _ = os.Setenv("NIX_BIN", old) }()
-
-	got, err := locateNixBinary()
-	if err != nil {
-		t.Fatalf("locateNixBinary env override failed: %v", err)
-	}
-	if got != fakeNix {
-		t.Fatalf("expected %q, got %q", fakeNix, got)
-	}
-}
-
-func TestSSHLocateNixBinaryHomeFallback(t *testing.T) {
-	tmp := t.TempDir()
-	fakeHome := filepath.Join(tmp, "home")
-	nixPath := filepath.Join(fakeHome, ".nix-profile/bin/nix")
-	if err := os.MkdirAll(filepath.Dir(nixPath), 0o755); err != nil {
-		t.Fatalf("mkdir home profile failed: %v", err)
-	}
-	if err := os.WriteFile(nixPath, []byte("#!/bin/sh\necho test\n"), 0o755); err != nil {
-		t.Fatalf("write fallback nix failed: %v", err)
-	}
-
-	oldHome := os.Getenv("HOME")
-	oldPath := os.Getenv("PATH")
-	oldNix := os.Getenv("NIX_BIN")
-	_ = os.Setenv("HOME", fakeHome)
-	_ = os.Setenv("NIX_BIN", "")
-	_ = os.Setenv("PATH", tmp)
-	defer func() {
-		_ = os.Setenv("HOME", oldHome)
-		_ = os.Setenv("PATH", oldPath)
-		_ = os.Setenv("NIX_BIN", oldNix)
-	}()
-
-	got, err := locateNixBinary()
-	if err != nil {
-		t.Fatalf("locateNixBinary fallback failed: %v", err)
-	}
-	if got != nixPath {
-		t.Fatalf("expected fallback %q, got %q", nixPath, got)
-	}
+	withShellSSH(t, "/nix/store/test-openssh/bin/ssh", func() {
+		cmd, err := buildSSHCommand(sshOptions{}, node)
+		if err != nil {
+			t.Fatalf("buildSSHCommand failed: %v", err)
+		}
+		if !strings.HasSuffix(cmd.Args[len(cmd.Args)-1], "user@gold.shad-artichoke.ts.net") {
+			t.Fatalf("expected tailnet host to be selected first, got target %q", cmd.Args[len(cmd.Args)-1])
+		}
+	})
 }
 
 func TestSSHDryRunDoesNotExecute(t *testing.T) {
 	tmp := t.TempDir()
-	nixPath := filepath.Join(tmp, "fake-nix")
-	if err := os.WriteFile(nixPath, []byte("#!/bin/sh\necho test\n"), 0o755); err != nil {
-		t.Fatalf("write fake nix failed: %v", err)
-	}
-
-	oldNixBin := os.Getenv("NIX_BIN")
 	oldRepoRoot := os.Getenv("DIALTONE_REPO_ROOT")
+	oldActive := os.Getenv("DIALTONE_NIX_ACTIVE")
+	oldSSHBin := os.Getenv("DIALTONE_SSH_BIN")
 	oldRunner := execRunner
 
 	if err := os.MkdirAll(filepath.Join(tmp, "env"), 0o755); err != nil {
@@ -256,11 +224,13 @@ func TestSSHDryRunDoesNotExecute(t *testing.T) {
 		return nil
 	}
 
-	_ = os.Setenv("NIX_BIN", nixPath)
 	_ = os.Setenv("DIALTONE_REPO_ROOT", tmp)
+	_ = os.Setenv("DIALTONE_NIX_ACTIVE", "1")
+	_ = os.Setenv("DIALTONE_SSH_BIN", "/nix/store/test-openssh/bin/ssh")
 	defer func() {
-		_ = os.Setenv("NIX_BIN", oldNixBin)
 		_ = os.Setenv("DIALTONE_REPO_ROOT", oldRepoRoot)
+		_ = os.Setenv("DIALTONE_NIX_ACTIVE", oldActive)
+		_ = os.Setenv("DIALTONE_SSH_BIN", oldSSHBin)
 		execRunner = oldRunner
 	}()
 
@@ -272,9 +242,22 @@ func TestSSHDryRunDoesNotExecute(t *testing.T) {
 	if executed {
 		t.Fatal("dry-run should not execute command")
 	}
-	if !strings.Contains(output, "nix command:") || !strings.Contains(output, "echo hi") {
+	if !strings.Contains(output, "command:") || !strings.Contains(output, "echo hi") {
 		t.Fatalf("dry-run output missing expected content: %q", output)
 	}
+}
+
+func withShellSSH(t *testing.T, sshBin string, fn func()) {
+	t.Helper()
+	oldActive := os.Getenv("DIALTONE_NIX_ACTIVE")
+	oldSSHBin := os.Getenv("DIALTONE_SSH_BIN")
+	_ = os.Setenv("DIALTONE_NIX_ACTIVE", "1")
+	_ = os.Setenv("DIALTONE_SSH_BIN", sshBin)
+	defer func() {
+		_ = os.Setenv("DIALTONE_NIX_ACTIVE", oldActive)
+		_ = os.Setenv("DIALTONE_SSH_BIN", oldSSHBin)
+	}()
+	fn()
 }
 
 func captureStdout(t *testing.T, fn func()) string {


### PR DESCRIPTION
## Summary
- move `repl v1` and `ssh v1` onto dedicated flake-backed dev shells and apps
- teach `dialtone_mod` to enter those shells and use Nix-provided tool paths for mod execution
- document the flake-first mod workflow in `plan/MODS_NIX_V1.md` and refresh the REPL/SSH mod docs and tests

## Testing
- `go test ./mods/repl/v1/... ./mods/ssh/v1`
- `nix --extra-experimental-features "nix-command flakes" flake check --no-build`
- `bash -n dialtone_mod`